### PR TITLE
Grunt tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,16 +300,12 @@ In order to run the tests, the following environment variables need to be set up
 
 Unix
 ```shell
-export AZURE_STORAGE_CONNECTION_STRING="valid storage connection string"
-# OR
 export AZURE_STORAGE_ACCOUNT="valid storage account name"
 export AZURE_STORAGE_ACCESS_KEY="valid storage account key"
 ```
 
 Windows
 ```Batchfile
-set AZURE_STORAGE_CONNECTION_STRING="valid storage connection string"
-:: OR
 set AZURE_STORAGE_ACCOUNT="valid storage account name"
 set AZURE_STORAGE_ACCESS_KEY="valid storage account key"
 ```

--- a/README.md
+++ b/README.md
@@ -298,13 +298,21 @@ How-Tos focused around accomplishing specific tasks are available on the [Micros
 
 In order to run the tests, the following environment variables need to be set up:
 
-AZURE_STORAGE_CONNECTION_STRING="valid storage connection string"
+Unix
+```shell
+export AZURE_STORAGE_CONNECTION_STRING="valid storage connection string"
+# OR
+export AZURE_STORAGE_ACCOUNT="valid storage account name"
+export AZURE_STORAGE_ACCESS_KEY="valid storage account key"
+```
 
-or 
-
-AZURE_STORAGE_ACCOUNT="valid storage account name"
-
-AZURE_STORAGE_ACCESS_KEY="valid storage account key"
+Windows
+```Batchfile
+set AZURE_STORAGE_CONNECTION_STRING="valid storage connection string"
+:: OR
+set AZURE_STORAGE_ACCOUNT="valid storage account name"
+set AZURE_STORAGE_ACCESS_KEY="valid storage account key"
+```
 
 In order to be able to use a proxy like fiddler, an additional environment variable should be set up:
 
@@ -312,7 +320,7 @@ HTTP_PROXY=http://127.0.0.1:8888
 
 The tests can then be run from the module's root directory using:
 
-`npm test`
+`grunt`
 
 # Need Help?
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -49,6 +49,17 @@ module.exports = function(grunt) {
             }
         }
     },
+    mochaTest: {
+      test: {
+        options: {
+          timeout: 3000,
+          reporter: 'spec',
+          quiet: false,
+          clearRequireCache: false
+        },
+        src: ['test/**/*.js']
+      }
+    },
     devserver: { options:
       { 'type' : 'http',
         'port' : 8888,
@@ -58,6 +69,8 @@ module.exports = function(grunt) {
   });
   grunt.loadNpmTasks('grunt-jsdoc');
   grunt.loadNpmTasks('grunt-devserver');
+  grunt.loadNpmTasks('grunt-mocha-test');
+  grunt.registerTask('default', 'mochaTest');
   
   grunt.loadTasks('tasks');
 

--- a/package.json
+++ b/package.json
@@ -30,17 +30,18 @@
     "request": "~2.27.0",
     "validator": "~3.1.0",
     "mime": "~1.2.4",
-    "underscore": "~1.4.4",
     "node-uuid": "~1.4.0",
     "extend": "~1.2.1"
   },
   "devDependencies": {
-    "mocha": ">= 1.18.0",
-    "jshint": ">= 2.1.4",
-    "should": "1.2.x",
     "grunt": "~0.4.2",
+    "grunt-devserver": "~0.4.1",
     "grunt-jsdoc": "~0.5.1",
-    "grunt-devserver": "~0.4.1"
+    "grunt-mocha": "^0.4.11",
+    "grunt-mocha-test": "^0.12.4",
+    "jshint": ">= 2.1.4",
+    "mocha": ">= 1.18.0",
+    "should": "1.2.x"
   },
   "homepage": "http://github.com/Azure/azure-storage-node",
   "repository": {


### PR DESCRIPTION
  -  Remove need for global mocha install.
  -  Make default grunt task to run unit tests


NOTE: Multiple unit tests currently fail, and failed prior to this change.