### PR TITLE
Fixed code sample in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Use **TableQuery** to build complex queries:
 ```Javascript
 var azure = require('azure-storage');
 var tableService = azure.createTableService();
-var query = azure.TableQuery()
+var query = new azure.TableQuery()
 		    .top(5)
 		    .where('PartitionKey eq ?', 'part2');
 


### PR DESCRIPTION
The `azure.TableQuery()` method requires the `new` keyword`