### PR TITLE
tableservice.js - "Cannot set property 'isSuccessful' of null" fix

### DIFF
--- a/lib/services/table/tableservice.js
+++ b/lib/services/table/tableservice.js
@@ -670,6 +670,7 @@ TableService.prototype.createTableIfNotExists = function (table, optionsOrCallba
         else if (createError && createError.statusCode === Constants.HttpConstants.HttpResponseCodes.Conflict && createError.code === Constants.TableErrorCodeStrings.TABLE_ALREADY_EXISTS) {
           createError = null;
           created = false;
+          if(!createResponse) createResponse = {};
           createResponse.isSuccessful = true;
         }
         callback(createError, created, createResponse);

--- a/lib/services/table/tableservice.js
+++ b/lib/services/table/tableservice.js
@@ -670,7 +670,9 @@ TableService.prototype.createTableIfNotExists = function (table, optionsOrCallba
         else if (createError && createError.statusCode === Constants.HttpConstants.HttpResponseCodes.Conflict && createError.code === Constants.TableErrorCodeStrings.TABLE_ALREADY_EXISTS) {
           createError = null;
           created = false;
-          if(!createResponse) createResponse = {};
+          if(!createResponse) {
+            createResponse = {};
+          }
           createResponse.isSuccessful = true;
         }
         callback(createError, created, createResponse);


### PR DESCRIPTION
`createResponse` within `createTableIfNotExists` on [line 665](https://github.com/Azure/azure-storage-node/blob/master/lib/services/table/tableservice.js#L665) is sometimes null when the table already exists as described in #31. This leads to an error when attempting to set `createResponse.isSuccessful` on [line 673](https://github.com/Azure/azure-storage-node/blob/master/lib/services/table/tableservice.js#L673) . To fix this, I have added a simple check such that a null `createResponse` is turned into an empty object so that the callback succeeds as it should.

Thanks.