### PR TITLE
Avoiding the global pool with stream requests

### DIFF
--- a/lib/common/services/storageserviceclient.js
+++ b/lib/common/services/storageserviceclient.js
@@ -15,6 +15,7 @@
 // 
 
 // Module dependencies.
+var https = require('https');
 var request = require('request');
 var url = require('url');
 var util = require('util');
@@ -364,20 +365,25 @@ StorageServiceClient.prototype._performRequest = function (webResource, body, op
 
           // Pipe any input / output streams
           if (body && body.inputStream) {
+            var agent = new https.Agent({ 'keep-alive': true });
+            finalRequestOptions.agent = agent;
             body.inputStream.on('close', function () {
               if (endResponse) {
+                agent.destroy();
                 processResponseCallback(null, endResponse);
                 endResponse = null;
               }
             });
             body.inputStream.on('end', function () {
               if (endResponse) {
+                agent.destroy();
                 processResponseCallback(null, endResponse);
                 endResponse = null;
               }
             });
             body.inputStream.on('finish', function () {
               if (endResponse) {
+                agent.destroy();
                 processResponseCallback(null, endResponse);
                 endResponse = null;
               }


### PR DESCRIPTION
These can sometimes hang indefinitely even after completing, corrupting the global stream pool and breaking downstream requests without throwing an error. It's safer to initialize these streams in their own agents. This issue has caused me many hours of silent outages.

Resolution for https://github.com/Azure/azure-storage-node/issues/104

Please let me know if you need any other information or code refactoring. Thanks!