### PR TITLE
Do not default appendPosition to 0 unless passed into appendBlockFromText

### DIFF
--- a/lib/services/blob/blobservice.js
+++ b/lib/services/blob/blobservice.js
@@ -4503,8 +4503,11 @@ BlobService.prototype._appendBlock = function (container, blob, content, stream,
     var webResource = WebResource.put(resourceName)
       .withQueryOption(QueryStringConstants.COMP, 'appendblock')
       .withHeader(HeaderConstants.CONTENT_LENGTH, length)
-      .withHeader(HeaderConstants.BLOB_CONDITION_MAX_SIZE, options.maxBlobSize)
-      .withHeader(HeaderConstants.BLOB_CONDITION_APPEND_POSITION, options.appendPosition || 0);
+      .withHeader(HeaderConstants.BLOB_CONDITION_MAX_SIZE, options.maxBlobSize);
+
+    if (options.hasOwnProperty('appendPosition')) {
+      webResource = webResource.withHeader(HeaderConstants.BLOB_CONDITION_APPEND_POSITION, options.appendPosition || 0);
+    }
 
     BlobResult.setHeadersFromBlob(webResource, options);
 


### PR DESCRIPTION
This parameter should be optional, but by defaulting it to 0 it's required. This makes it so that it's only passed through if the user specifies the value.