### PR TITLE
No network timeout

### DIFF
--- a/lib/common/services/storageserviceclient.js
+++ b/lib/common/services/storageserviceclient.js
@@ -551,6 +551,7 @@ StorageServiceClient.prototype._buildRequestOptions = function (webResource, bod
       if(options) {
         //set encoding of response data. If set to null, the body is returned as a Buffer
         requestOptions.encoding = options.responseEncoding;
+        requestOptions.timeout = options.timeoutIntervalInMs;
       }
     }
 


### PR DESCRIPTION
If the network connection to the Azure servers should go down then we do not a timeout from the node Azure library.  I simulated this scenario by setting the primaryHost to point to a *nix discard-stream service.

This pull request fixes the problem although I am aware that I have used the timeoutIntervalInMs option.  Although, I would suggest that the timeout on the client side is more important than that on the server.  Should there be an additional timeout???

I also notice that the node library set timeoutIntervalInMs as the query string timeout parameter.  In the REST API documentation (https://msdn.microsoft.com/en-GB/library/azure/dd179451.aspx) the timeout is specified as being in seconds.  So, is it in milliseconds or seconds.

I hope this of help to you!

