### PR TITLE
Fix range error

### DIFF
--- a/lib/common/services/storageserviceclient.js
+++ b/lib/common/services/storageserviceclient.js
@@ -551,7 +551,6 @@ StorageServiceClient.prototype._buildRequestOptions = function (webResource, bod
       if(options) {
         //set encoding of response data. If set to null, the body is returned as a Buffer
         requestOptions.encoding = options.responseEncoding;
-        requestOptions.timeout = options.timeoutIntervalInMs;
       }
     }
 

--- a/lib/common/services/storageserviceclient.js
+++ b/lib/common/services/storageserviceclient.js
@@ -551,6 +551,7 @@ StorageServiceClient.prototype._buildRequestOptions = function (webResource, bod
       if(options) {
         //set encoding of response data. If set to null, the body is returned as a Buffer
         requestOptions.encoding = options.responseEncoding;
+        requestOptions.timeout = options.timeoutIntervalInMs;
       }
     }
 

--- a/lib/services/blob/internal/blockrangestream.js
+++ b/lib/services/blob/internal/blockrangestream.js
@@ -105,7 +105,7 @@ BlockRangeStream.prototype._getTypeList = function (callback) {
   try {
     var typeStart = false;
     for (var blockType in this._rangelist) {
-      if (this._rangelist.hasOwnProperty(blockType)) {
+      if (this._rangelist && this._rangelist.hasOwnProperty(blockType)) {
         if (this._emittedRangeType === null || typeStart || this._emittedRangeType == blockType) {
           this._emittedRangeType = blockType;
           typeStart = true;


### PR DESCRIPTION
When calling the getBlobToStream() function I was getting the following error:
'''
     Uncaught TypeError: Cannot read property 'hasOwnProperty' of null
      at BlockRangeStream._getTypeList (node_modules/azure-storage/lib/services/blob/internal/blockrangestream.js:108:26)
      at BlockRangeStream._emitBlockList (node_modules/azure-storage/lib/services/blob/internal/blockrangestream.js:93:8)
      at node_modules/azure-storage/lib/services/blob/internal/blockrangestream.js:80:12
      at finalCallback (node_modules/azure-storage/lib/services/blob/blobservice.js:3266:7)
      at node_modules/azure-storage/lib/common/services/storageserviceclient.js:832:11
      at processResponseCallback (node_modules/azure-storage/lib/services/blob/blobservice.js:3269:5)
      at Request.processResponseCallback [as _callback] (node_modules/azure-storage/lib/common/services/storageserviceclient.js:290:13)
      at Request.self.callback (node_modules/azure-storage/node_modules/request/request.js:354:22)
      at Request.<anonymous> (node_modules/azure-storage/node_modules/request/request.js:1207:14)
      at IncomingMessage.<anonymous> (node_modules/azure-storage/node_modules/request/request.js:1153:12)
      at _stream_readable.js:908:16
'''

It turns out that _getTypeList was extracting the commited blocks from the rangeList and then executing the callback via _emitBlockRange.  In the callback we delete the rangeList.  Then, getTypeList attempts to process the uncomitted blocks but the rangeList was already removed.

In this PR I have modified the code to ensure that the rangeList array still exists before continuing.

A more correct fix might be to have _getTypeList call the callback only when both the committed and uncomitted blocks have been processed.

