### PR TITLE
Updated .npmignore to reduce npm module size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,4 +5,8 @@
 node_modules/
 
 # Examples #
-examples/blobuploader/
+examples/
+
+jsdoc/
+test/
+typings/


### PR DESCRIPTION
Azure storage npm module is ~80MB, lots of unnecessary files are ending up in there (I'm looking at you https://github.com/Azure/azure-storage-node/blob/master/test/recordings/blobservice-uploaddownload-tests.nock.js).  

This should reduce it to <5MB, if you want to dive even deeper feel free!