### PR TITLE
Add 'EAI_AGAIN' as a default retry error code

### DIFF
--- a/lib/common/filters/retrypolicyfilter.js
+++ b/lib/common/filters/retrypolicyfilter.js
@@ -128,7 +128,7 @@ RetryPolicyFilter._handle = function (self, requestOptions, next) {
         // In this case, we should not retry the request.
         if (returnObject.error && azureutil.objectIsNull(returnObject.retryable) &&
              ((!azureutil.objectIsNull(returnObject.response) && retryInfo.retryable) || 
-               (returnObject.error.code === 'ETIMEDOUT' || returnObject.error.code === 'ESOCKETTIMEDOUT' || returnObject.error.code === 'ECONNRESET'))) {
+               (returnObject.error.code === 'ETIMEDOUT' || returnObject.error.code === 'ESOCKETTIMEDOUT' || returnObject.error.code === 'ECONNRESET' || returnObject.error.code === 'EAI_AGAIN'))) {
 
           if (retryRequestOptions.currentLocation === Constants.StorageLocation.PRIMARY) {
             lastPrimaryAttempt = returnObject.operationEndTime;


### PR DESCRIPTION
The reason for adding this is it is frequently seen when sending a multitude of requests in parallel.