### PR TITLE
Avoid high memory usage with parallel uploads

### DIFF
--- a/lib/common/filters/retrypolicyfilter.js
+++ b/lib/common/filters/retrypolicyfilter.js
@@ -128,7 +128,7 @@ RetryPolicyFilter._handle = function (self, requestOptions, next) {
         // In this case, we should not retry the request.
         if (returnObject.error && azureutil.objectIsNull(returnObject.retryable) &&
              ((!azureutil.objectIsNull(returnObject.response) && retryInfo.retryable) || 
-               (returnObject.error.code === 'ETIMEDOUT' || returnObject.error.code === 'ESOCKETTIMEDOUT' || returnObject.error.code === 'ECONNRESET'))) {
+               (returnObject.error.code === 'ETIMEDOUT' || returnObject.error.code === 'ESOCKETTIMEDOUT' || returnObject.error.code === 'ECONNRESET' || returnObject.error.code === 'EAI_AGAIN'))) {
 
           if (retryRequestOptions.currentLocation === Constants.StorageLocation.PRIMARY) {
             lastPrimaryAttempt = returnObject.operationEndTime;

--- a/lib/services/blob/blobservice.js
+++ b/lib/services/blob/blobservice.js
@@ -3987,7 +3987,10 @@ BlobService.prototype._createBlobFromLocalFile = function (container, blob, blob
         }
         callback(createError, createBlob, createResponse);
       };
-      self._uploadBlobFromStream(true, container, blob, blobType, stream, size, options, streamCallback);
+      self._uploadBlobFromStream(true, container, blob, blobType, stream, size, options, function () {
+        stream.finish(); // Avoid a memory surge
+        streamCallback();
+      });
     }
   };
 


### PR DESCRIPTION
When leaving the stream lingering before the subsequent callback, high memory usage has been seen when multiple uploads are happening in parallel. Calling the finish() method to flush to the underlying system alleviates that pressure.