### PR TITLE
add typings reference in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "author": "Microsoft Corporation",
   "version": "1.2.0",
   "description": "Microsoft Azure Storage Client Library for Node.js",
+  "typings": "typings/azure-storage/azure-storage.d.ts",
   "tags": [
     "azure",
     "storage",


### PR DESCRIPTION
Update `package.json` to include a `typings` reference to the type definition making this package more typings friendly. See #152, specifically this comment https://github.com/Azure/azure-storage-node/issues/152#issuecomment-235195913 for reference.

The work was mostly done by @SomaticIT & suggested by @mikesouth... I'm responding to @hasonmsft's last comment... sorry... I got impatient :)