### PR TITLE
Add rule to exclude tests artefacts from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ coverage
 
 # Editor configuration
 .vscode/*
+
+# Tests artefacts
+fileservice_test_*
+blobservice_test.tmp


### PR DESCRIPTION
This is a small change useful when tests using real Azure Storage account
are run - the rule excludes unintentional staging of broken
tests artefacts.

Thanks!
