### PR TITLE
Replace Grunt plugin for NSP checks

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -18,7 +18,9 @@ module.exports = function(grunt) {
   //init stuff
   grunt.initConfig({
 
-    pkg: grunt.file.readJSON('package.json'),
+    nsp: {
+      package: grunt.file.readJSON('package.json')
+    },
 
     mochaTest: {
       test: {
@@ -91,10 +93,10 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-jsdoc');
   grunt.loadNpmTasks('grunt-mocha-test');
   grunt.loadNpmTasks('grunt-devserver');
-  grunt.loadNpmTasks('grunt-nsp-package');
+  grunt.loadNpmTasks('grunt-nsp');
   grunt.loadNpmTasks('grunt-contrib-jshint');
 
   grunt.registerTask('doc', ['jsdoc', 'devserver']);
-  grunt.registerTask('validate', ['jshint', 'validate-package']);
+  grunt.registerTask('validate', ['jshint', 'nsp']);
   grunt.registerTask('default', ['validate', 'mochaTest']);
 };

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "grunt-jsdoc": "~0.5.1",
     "grunt-mocha": "^0.4.12",
     "grunt-mocha-test": "^0.12.7",
-    "grunt-nsp-package": "0.0.5",
+    "grunt-nsp": "^2.3.1",
     "istanbul": "^0.3.22",
     "jshint": ">= 2.1.4",
     "mocha": ">= 1.18.0",


### PR DESCRIPTION
This commit removes outdated NPM module for Grunt
with different module that replaced old one.
This will remove warning message when this library
is installed:

``` bash
npm WARN deprecated grunt-nsp-package@0.0.5: new api version released, use grunt-nsp instead
```

``` bash
➜  azure-storage-node git:(dev) grunt validate
Running "jshint:all" (jshint) task
>> 65 files lint free.

Running "validate-package" task
/Users/piotrblazejewicz/git/azure-storage-node/package.json
```

Thanks!
