### PR TITLE
Updated azure-storage.d.ts for no implicit any

### DIFF
--- a/typings/azure-storage/azure-storage.d.ts
+++ b/typings/azure-storage/azure-storage.d.ts
@@ -7156,7 +7156,7 @@ declare module azurestorage {
           * };
           * var blobService = azure.createBlobService().withFilter(retryPolicy);
           */
-          constructor(retryCount?: number, retryInterval?: number);
+          constructor(retryCount?: number, retryInterval?: number):any;
           
           shouldRetry(statusCode: number, retryData: RetryPolicyFilter.IRetryRequestOptions): {
             retryInterval: number;
@@ -8776,7 +8776,7 @@ declare module azurestorage {
   */
   export function createQueueServiceWithSas(hostUri: string | StorageHost, sasToken: string): QueueService;
   
-  export function generateAccountSharedAccessSignature(storageAccountOrConnectionString: string, storageAccessKey: string, sharedAccessAccountPolicy: common.SharedAccessPolicy);
+  export function generateAccountSharedAccessSignature(storageAccountOrConnectionString: string, storageAccessKey: string, sharedAccessAccountPolicy: common.SharedAccessPolicy):any;
 
   interface StorageError extends Error {
     statusCode?: number;


### PR DESCRIPTION
If you use typescript and have the option "noImplicitAny" enabled, tsc will complain when trying to compile azure-storage, this can be easily fixed by adding an explicit any in 2 lines.