### PR TITLE
Storage Client Library 1.4.0

### DIFF
--- a/BreakingChanges.md
+++ b/BreakingChanges.md
@@ -1,3 +1,10 @@
+Tracking Breaking Changes in 1.4.0
+BLOB
+* Changed `/S` of SpeedSummary to `/s`.
+
+FILE
+* Changed `/S` of SpeedSummary to `/s`.
+
 Tracking Breaking Changes in 1.3.0
 QUEUE
 * Updated the `QueueMessageResult.dequeueCount` from `string` to `number`.

--- a/BreakingChanges.md
+++ b/BreakingChanges.md
@@ -1,4 +1,5 @@
 Tracking Breaking Changes in 1.4.0
+
 BLOB
 * Changed `/S` of SpeedSummary to `/s`.
 
@@ -6,14 +7,17 @@ FILE
 * Changed `/S` of SpeedSummary to `/s`.
 
 Tracking Breaking Changes in 1.3.0
+
 QUEUE
 * Updated the `QueueMessageResult.dequeueCount` from `string` to `number`.
 
 Tracking Breaking Changes in 1.2.0
+
 TABLE
 * Beginning with version 2015-12-11, the Atom feed is no longer supported as a payload format for Table service operations. Version 2015-12-11 and later versions support only JSON for the payload format.
 
 Tracking Breaking Changes in 1.0.0
+
 BLOB
 * The `blob` property of BlobResult has been renamed to `name` to keep consistent with other services API and the `listBlob` API.
 * Decoded the block name of LockListResult from base64 string to utf-8 string.
@@ -22,6 +26,7 @@ QUEUE
 * The `encodeMessage` flag of QueueService has been replaced by `messageEncoder` which support `TextBase64QueueMessageEncoder`, `BinaryBase64QueueMessageEncoder`, `TextXmlQueueMessageEncoder` and custom implementation of QueueMessageEncoder.
 
 Tracking Breaking Changes in 0.10.0
+
 ALL
 * The `signedIdentifiers` parameter and result properties have been changed from array to hash map to avoid non unique signed identifier id.
 
@@ -50,6 +55,7 @@ TABLE
 * Renamed TableUtilities.entityGenerator.Entity to EntityProperty.
 
 Tracking Breaking Changes in 0.7.0
+
 ALL
 * The generateDevelopmentStorageCredendentials function in the azure-storage.js is renamed to generateDevelopmentStorageCredentials.
 
@@ -67,6 +73,7 @@ FILE
 * The property names returned from getting share stats are changed to camelCase.
 
 Tracking Breaking Changes in 0.5.0
+
 ALL
 * The suffix "_HEADER" is removed from all the http header constants.
 * The generateSharedAccessSignatureWithVersion function in each service is deprecated.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,9 +5,11 @@ be taken. This is a GA release and the changes described below indicate the chan
 
 BLOB
 * Fixed the issue that the ChunkAllocator maxCount is aligned with parallelOperationThreadCount.
+* Changed `/S` of SpeedSummary to `/s`.
 
 FILE
 * Fixed the issue that the ChunkAllocator maxCount is aligned with parallelOperationThreadCount.
+* Changed `/S` of SpeedSummary to `/s`.
 
 2016.10 Version 1.3.2
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,14 @@
 Note: This is an Azure Storage only package. The all up Azure node sdk still has the old storage bits in there. In a future release, those storage bits will be removed and an npm dependency to this storage node sdk will 
 be taken. This is a GA release and the changes described below indicate the changes from the Azure node SDK 0.9.8 available here - https://github.com/Azure/azure-sdk-for-node.
 
+2016.11 Version 1.4.0
+
+BLOB
+* Fixed the issue that the ChunkAllocator maxCount is aligned with parallelOperationThreadCount.
+
+FILE
+* Fixed the issue that the ChunkAllocator maxCount is aligned with parallelOperationThreadCount.
+
 2016.10 Version 1.3.2
 
 BLOB

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ be taken. This is a GA release and the changes described below indicate the chan
 BLOB
 * Fixed the issue that the ChunkAllocator maxCount is aligned with parallelOperationThreadCount.
 * Changed `/S` of SpeedSummary to `/s`.
+* Fixed the issue that `BlobService.createBlockBlobFromText` will hang when passed `null` or `undefined` `text` argument. 
 
 FILE
 * Fixed the issue that the ChunkAllocator maxCount is aligned with parallelOperationThreadCount.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ BLOB
 * Fixed the issue that the ChunkAllocator maxCount is aligned with parallelOperationThreadCount.
 * Changed `/S` of SpeedSummary to `/s`.
 * Fixed the issue that `BlobService.createBlockBlobFromText` will hang when passed `null` or `undefined` `text` argument. 
+* Fixed the issue that `BlobService.createBlockBlobFromText` will always set `content-type` to `text/plain`.
 
 FILE
 * Fixed the issue that the ChunkAllocator maxCount is aligned with parallelOperationThreadCount.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,9 @@ be taken. This is a GA release and the changes described below indicate the chan
 
 2016.11 Version 1.4.0
 
+ALL
+* Added `ENOTFOUND` for secondary endpoint and `ECONNREFUSED` to `RetryPolicyFilter`.
+
 BLOB
 * Fixed the issue that the ChunkAllocator maxCount is aligned with parallelOperationThreadCount.
 * Changed `/S` of SpeedSummary to `/s`.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,9 @@ BLOB
 * Fixed the issue that `BlobService.createBlockBlobFromText` will hang when passed `null` or `undefined` `text` argument. 
 * Fixed the issue that `BlobService.createBlockBlobFromText` will always set `content-type` to `text/plain`.
 
+QUEUE
+* Allowed `QueueService.peekMessages` against secondary endpoint.
+
 FILE
 * Fixed the issue that the ChunkAllocator maxCount is aligned with parallelOperationThreadCount.
 * Changed `/S` of SpeedSummary to `/s`.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ be taken. This is a GA release and the changes described below indicate the chan
 
 ALL
 * Added `ENOTFOUND` for secondary endpoint and `ECONNREFUSED` to `RetryPolicyFilter`.
+* Added support for `text/html` error response body.
 
 BLOB
 * Fixed the issue that the ChunkAllocator maxCount is aligned with parallelOperationThreadCount.

--- a/README.md
+++ b/README.md
@@ -431,15 +431,10 @@ By default the unit tests are ran with Nock recording data. To run tests against
 set NOCK_OFF=true
 ```
 
-and set up the following environment variables for storage account credentials by 
+and set up the following environment variable for storage account credentials by 
 
 ```Batchfile
 set AZURE_STORAGE_CONNECTION_STRING="valid storage connection string"
-```
-or 
-```Batchfile
-set AZURE_STORAGE_ACCOUNT="valid storage account name"
-set AZURE_STORAGE_ACCESS_KEY="valid storage account key"
 ```
 
 To record the data in a test pass against real storage account for future Nock usage:

--- a/examples/blobuploader/app.js
+++ b/examples/blobuploader/app.js
@@ -14,71 +14,50 @@
 // limitations under the License.
 // 
 
-var fs = require('fs');
-if (!fs.existsSync) {
-  fs.existsSync = require('path').existsSync;
-}
-
-var azure;
-if (fs.existsSync('absolute path to azure-storage.js')) {
-  azure = require('absolute path to azure-storage');
-} else {
-  azure = require('azure-storage');
-}
-
 var express = require('express');
+var expressLayouts = require('express-ejs-layouts');
+var path = require('path');
+var azure = require('azure-storage');
 var formidable = require('formidable');
 var helpers = require('./helpers.js');
 
-var app = module.exports = express.createServer();
+var app = express();
+
 // Global request options, set the retryPolicy
 var blobClient = azure.createBlobService('UseDevelopmentStorage=true').withFilter(new azure.ExponentialRetryPolicyFilter());
 var containerName = 'webpi';
 
 //Configuration
-app.configure(function () {
-  app.set('views', __dirname + '/views');
-  app.set('view engine', 'ejs');
-  app.use(express.methodOverride());
-  // app.use(express.logger());
-  app.use(app.router);
-  app.use(express.static(__dirname + '/public'));
-});
+app.set('views', path.join(__dirname + '/views'));
+app.set('view engine', 'ejs');
+app.set('layout', 'layout');
+app.use(express.static(path.join(__dirname + '/public')));
+app.use(expressLayouts);
 
-app.configure('development', function () {
+app.set('development', function(){
   app.use(express.errorHandler({ dumpExceptions: true, showStack: true }));
 });
 
-app.configure('production', function () {
+app.set('production', function(){
   app.use(express.errorHandler());
 });
 
-app.param(':id', function (req, res, next) {
+app.param('id', function (req, res, next) {
   next();
 });
 
 //Routes
 app.get('/', function (req, res) {
-  res.render('index.ejs', { locals: {
-    title: 'Welcome'
-  }
-  });
+  res.render('index.ejs', { title: 'Welcome' });
 });
 
 app.get('/Upload', function (req, res) {
-  res.render('upload.ejs', { locals: {
-    title: 'Upload File'
-  }
-  });
+  res.render('upload.ejs', { title: 'Upload File' });
 });
 
 app.get('/Display', function (req, res) {
-  blobClient.listBlobs(containerName, function (error, blobs) {
-    res.render('display.ejs', { locals: {
-      title: 'List of Blobs',
-      serverBlobs: blobs
-    }
-    });
+  blobClient.listBlobsSegmented(containerName, null, function (error, blobs, result) {
+    res.render('display.ejs', { title: 'List of Blobs', serverBlobs: blobs.entries });
   });
 });
 
@@ -117,7 +96,6 @@ app.post('/uploadhandler', function (req, res) {
         if (error != null) {
           helpers.renderError(res);
         } else {
-          setSAS(containerName, fields.itemName);
           res.redirect('/Display');
         }
       });
@@ -145,25 +123,13 @@ blobClient.createContainerIfNotExists(containerName, function (error) {
   }
 });
 
-function setSAS(containerName, blobName) {
-    var sharedAccessPolicy = {
-        AccessPolicy: {
-            Expiry: azure.date.minutesFromNow(3)
-        }
-    };   
-    
-    var blobUrl = blobClient.getBlobUrl(containerName, blobName, sharedAccessPolicy);
-    console.log("access the blob at ", blobUrl);
-}
-
 function setPermissions() {
   var options = { publicAccessLevel: azure.BlobUtilities.BlobContainerPublicAccessType.BLOB };
   blobClient.setContainerAcl(containerName, null, options, function (error) {
     if (error) {
       console.log(error);
-    } else {
-      app.listen(process.env.port || 1337);
-      console.log("Express server listening on port %d in %s mode", app.address().port, app.settings.env);
-    }
+    } 
   });
 }
+
+module.exports = app;

--- a/examples/blobuploader/bin/server.js
+++ b/examples/blobuploader/bin/server.js
@@ -1,0 +1,82 @@
+/**
+ * Module dependencies
+ */
+
+var app = require('../app');
+var debug = require('debug')('blobuploader:server');
+var http = require('http');
+
+/**
+ * Get port from environment and store in express app
+ */
+
+var port = normalizePort(process.env.PORT || '3000');
+app.set('port', port);
+
+/**
+ * Create HTTP server
+ */
+
+var server = http.createServer(app);
+
+/**
+ * Listen on provided port, on all network inferfaces
+ */
+
+server.listen(port);
+server.on('error', onError);
+server.on('listening', onListening);
+
+/**
+ * Normalize a port into a number, string, or false.
+ */
+
+function normalizePort(val) {
+	var port = parseInt(val, 10);
+	
+	if (isNaN(port)){
+		return val;
+	}
+	
+	if (port >= 0) {
+		return port;
+	}
+	
+	return false;
+}
+
+/** 
+ * Event listener for HTTP server "error" event
+ */
+
+function onError(error) {
+	if (error.syscall !== 'listen') {
+		throw error;
+	}
+	
+	var bind = typeof port === 'string' ? 'Pipe ' + port : 'Port ' + port;
+	
+	// handle specific listen errors with friendly messages
+	switch (error.code) {
+		case 'EACCES':
+			console.error(bind + ' requires elevated privileges');
+			process.exit(1);
+			break;
+		case 'EADDRINUSE':
+			console.error(bind + ' is already in use');
+			process.exit(1);
+			break;
+		default:
+			throw error;
+	}
+}
+
+/**
+ * Event listener for HTTP server "listening" event.
+ */
+
+function onListening() {
+	var addr = server.address();
+	var bind = typeof addr === 'string' ? 'pipe ' + addr : 'port ' + addr.port;
+	debug('Listening on ' + bind);
+}

--- a/examples/blobuploader/package.json
+++ b/examples/blobuploader/package.json
@@ -1,11 +1,16 @@
 {
-    "name": "productmanager"
-  , "version": "0.0.1"
-  , "private": true
-  , "dependencies": {
-      "express": "2.x"
-    , "ejs": ">= 0.4.3"
-    , "formidable": ">= 1.0.6"
-    , "azure": ">= 0.5.1"
+  "name": "azurestorageblobuploadersample",
+  "version": "0.0.2",
+  "private": true,
+  "scripts": {
+    "start": "node ./bin/server.js"
+  },
+  "dependencies": {
+    "azure-storage": "",
+    "debug": "^2.2.0",
+    "ejs": "~2.3.3",
+    "express": "~4.13.1",
+    "express-ejs-layouts": "^1.1.0",
+    "formidable": "^1.0.17"
   }
 }

--- a/lib/common/filters/retrypolicyfilter.js
+++ b/lib/common/filters/retrypolicyfilter.js
@@ -105,8 +105,8 @@ RetryPolicyFilter._handle = function (self, requestOptions, next) {
         // If a request sent to the secondary location fails with 404 (Not Found), it is possible
         // that the resource replication is not finished yet. So, in case of 404 only in the secondary
         // location, the failure should still be retryable.
-        var secondaryNotFound = (retryRequestOptions.currentLocation === Constants.StorageLocation.SECONDARY) && (returnObject.response && returnObject.response.statusCode === 404);
-
+        var secondaryNotFound = (retryRequestOptions.currentLocation === Constants.StorageLocation.SECONDARY) && ((returnObject.response && returnObject.response.statusCode === 404) || (returnObject.error && returnObject.error.code === 'ENOTFOUND'));
+ 
         var retryInfo = self.shouldRetry(secondaryNotFound ? 500 : (azureutil.objectIsNull(returnObject.response) ? 306 : returnObject.response.statusCode), retryRequestOptions);
         retryRequestOptions.retryContext.retryCount++;
         
@@ -130,7 +130,7 @@ RetryPolicyFilter._handle = function (self, requestOptions, next) {
         // we should NOT retry within the SDK as the stream data is not valid anymore if we retry directly.
         if (!returnObject.outputStreamSent && returnObject.error && azureutil.objectIsNull(returnObject.retryable) &&
              ((!azureutil.objectIsNull(returnObject.response) && retryInfo.retryable) || 
-               (returnObject.error.code === 'ETIMEDOUT' || returnObject.error.code === 'ESOCKETTIMEDOUT' || returnObject.error.code === 'ECONNRESET' || returnObject.error.code === 'EAI_AGAIN'))) {
+               (returnObject.error.code === 'ECONNREFUSED' || returnObject.error.code === 'ETIMEDOUT' || returnObject.error.code === 'ESOCKETTIMEDOUT' || returnObject.error.code === 'ECONNRESET' || returnObject.error.code === 'EAI_AGAIN'))) {
 
           if (retryRequestOptions.currentLocation === Constants.StorageLocation.PRIMARY) {
             lastPrimaryAttempt = returnObject.operationEndTime;

--- a/lib/common/services/storageserviceclient.js
+++ b/lib/common/services/storageserviceclient.js
@@ -834,6 +834,8 @@ StorageServiceClient._parseResponse = function (response, xml2jsSettings, option
         }
       } else if (contentType.indexOf('application/xml') !== -1 || contentType.indexOf('application/atom+xml') !== -1) {
         response.body = parseXml(response.body);
+      } else if (contentType.indexOf('text/html') !== -1) {
+        response.body = response.body;
       } else {
         throw new SyntaxError(SR.CONTENT_TYPE_MISSING, null);
       }

--- a/lib/common/streams/speedsummary.js
+++ b/lib/common/streams/speedsummary.js
@@ -108,7 +108,7 @@ SpeedSummary.prototype._getInternalSpeed = function(totalSize, elapsedTime, huma
   }
   var speed = totalSize / elapsedTime;
   if(humanReadable !== false) {
-    speed = toHumanReadableSize(speed) + '/S';
+    speed = toHumanReadableSize(speed) + '/s';
   }
   return speed;
 };

--- a/lib/common/util/constants.js
+++ b/lib/common/util/constants.js
@@ -31,7 +31,7 @@ var Constants = {
   /*
   * Specifies the value to use for UserAgent header.
   */
-  USER_AGENT_PRODUCT_VERSION: '1.3.2',
+  USER_AGENT_PRODUCT_VERSION: '1.4.0',
 
   /**
   * The number of default concurrent requests for parallel operation.

--- a/lib/services/blob/blobservice.js
+++ b/lib/services/blob/blobservice.js
@@ -4259,7 +4259,7 @@ BlobService.prototype._createBlobFromText = function (container, blob, blobType,
     }
   };
 
-  var contentLength = (Buffer.isBuffer(content) ? content.length : Buffer.byteLength(content));
+  var contentLength = azureutil.objectIsNull(content) ? 0 : ((Buffer.isBuffer(content) ? content.length : Buffer.byteLength(content)));
   this._createBlob(container, blob, blobType, contentLength, options, creationCallback);
 
   return options.speedSummary; 
@@ -4515,12 +4515,12 @@ BlobService.prototype._uploadBlobFromText = function (isNewBlob, container, blob
   var options;
   azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { options = o; callback = c; });
   options.speedSummary = options.speedSummary || new SpeedSummary(blob);
-  options[HeaderConstants.CONTENT_TYPE] = 'text/plain;charset="utf-8"'; 
+  options[HeaderConstants.CONTENT_TYPE] = 'text/plain;charset="utf-8"';
 
   var self = this;
   var startUpload = function () {
     var operationFunc;
-    var length = Buffer.isBuffer(content) ? content.length : Buffer.byteLength(content);
+    var length = azureutil.objectIsNull(content) ? 0 : (Buffer.isBuffer(content) ? content.length : Buffer.byteLength(content));
 
     if (blobType === BlobConstants.BlobTypes.BLOCK) {
       // default to true, unless explicitly set to false
@@ -4622,7 +4622,7 @@ BlobService.prototype._putBlockBlob = function (container, blob, text, stream, l
   if (!options.speedSummary) {
     options.speedSummary = new SpeedSummary(blob);
   }
-  
+
   var speedSummary = options.speedSummary;
   speedSummary.totalSize = length;
 

--- a/lib/services/blob/blobservice.js
+++ b/lib/services/blob/blobservice.js
@@ -4999,7 +4999,7 @@ BlobService.prototype._uploadContentFromChunkStream = function (container, blob,
   speedSummary.totalSize = streamLength;
 
   // initialize chunk allocator
-  var allocator = new ChunkAllocator(sizeLimitation, options.parallelOperationThreadCount, { logger: this.logger });
+  var allocator = new ChunkAllocator(sizeLimitation, parallelOperationThreadCount, { logger: this.logger });
   chunkStream.setOutputLength(streamLength);
 
   // if this is a FileReadStream, set the allocator on that stream

--- a/lib/services/blob/blobservice.js
+++ b/lib/services/blob/blobservice.js
@@ -4515,7 +4515,7 @@ BlobService.prototype._uploadBlobFromText = function (isNewBlob, container, blob
   var options;
   azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { options = o; callback = c; });
   options.speedSummary = options.speedSummary || new SpeedSummary(blob);
-  options[HeaderConstants.CONTENT_TYPE] = 'text/plain;charset="utf-8"';
+  options[HeaderConstants.CONTENT_TYPE] = (options.contentSettings && options.contentSettings.contentType) || 'text/plain;charset="utf-8"';
 
   var self = this;
   var startUpload = function () {

--- a/lib/services/file/fileservice.js
+++ b/lib/services/file/fileservice.js
@@ -3211,7 +3211,7 @@ FileService.prototype._createFileFromChunkStream = function(share, directory, fi
   var parallelOperationThreadCount = options.parallelOperationThreadCount || this.parallelOperationThreadCount;
 
   // initialize chunk allocator
-  var allocator = new ChunkAllocator(sizeLimitation, options.parallelOperationThreadCount, { logger: this.logger });
+  var allocator = new ChunkAllocator(sizeLimitation, parallelOperationThreadCount, { logger: this.logger });
 
   // if this is a FileReadStream, set the allocator on that stream
   if (chunkStream._stream && chunkStream._stream.setMemoryAllocator) {

--- a/lib/services/queue/queueservice.js
+++ b/lib/services/queue/queueservice.js
@@ -1355,6 +1355,12 @@ QueueService.prototype._getOrPeekMessages = function (queue, optionsOrCallback, 
     .withQueryOption(QueryStringConstants.VISIBILITY_TIMEOUT, options.visibilityTimeout)
     .withQueryOption(QueryStringConstants.PEEK_ONLY, options.peekOnly);
 
+  if (options.peekOnly) {
+    // For peek message, it's a read-only action and can be performed against secondary endpoint.
+    options.requestLocationMode = RequestLocationMode.PRIMARY_OR_SECONDARY;
+  }
+
+
   var messageEncoder = this.messageEncoder;
   var processResponseCallback = function (responseObject, next) {
     responseObject.queueMessageResults = null;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-storage",
   "author": "Microsoft Corporation",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Microsoft Azure Storage Client Library for Node.js",
   "typings": "typings/azure-storage/azure-storage.d.ts",
   "tags": [

--- a/test/common/filters/exponentialretrypolicyfilter-tests.js
+++ b/test/common/filters/exponentialretrypolicyfilter-tests.js
@@ -174,7 +174,7 @@ describe('exponentialretrypolicyfilter-tests', function () {
     var fileSize = 100;
 
     // Real stream length is smaller than the expected data length to mock the client timeout error to trigger the retry
-    var fileBuffer = new Buffer( fileSize % 2 );
+    var fileBuffer = new Buffer( fileSize / 2 );
     fileBuffer.fill(1);
     fs.writeFileSync(localTempFileName, fileBuffer);
     
@@ -185,7 +185,7 @@ describe('exponentialretrypolicyfilter-tests', function () {
 
       fileService.createFile(shareName, '', fileName, fileSize, function(err) {
         assert.equal(err, null);
-
+        
         // Expect 100 bytes to sent but the stream only have 50 bytes.
         // It'll result in ECONNRESET error and should NOT retry. If retry, it'll hang to wait for data from the stream but the stream is already closed as the data already sent out in the 1st failed request.
         fileService.createRangesFromStream(shareName, '', fileName, rfs.createReadStream(localTempFileName), 0, fileSize - 1, function(err, result, response){

--- a/test/common/util/util-tests.js
+++ b/test/common/util/util-tests.js
@@ -133,7 +133,7 @@ describe('speed-summary-tests', function() {
     summary.totalSize = 100;
     summary.completeSize = 10;
     console.log(summary.getAverageSpeed(false));
-    assert.equal(summary.getAverageSpeed(true), '10.00B/S');
+    assert.equal(summary.getAverageSpeed(true), '10.00B/s');
     assert.equal(summary.getAverageSpeed(false).toString(), '10');
     done();
   });
@@ -142,7 +142,7 @@ describe('speed-summary-tests', function() {
     var summary = new speedSummary('test');
     summary.totalSize = 100;
     summary.completeSize = 15;
-    assert.equal(summary.getSpeed(true), '0B/S');
+    assert.equal(summary.getSpeed(true), '0B/s');
     assert.equal(summary.getSpeed(false).toString(), '0');
     done();
   });

--- a/test/services/blob/blobservice-uploaddownload-tests.js
+++ b/test/services/blob/blobservice-uploaddownload-tests.js
@@ -228,6 +228,30 @@ describe('blob-uploaddownload-tests', function () {
       });
     });
   });
+
+  it('createBlockBlobFromText with specified content type', function (done) {
+    var blobName = 'blobs/' + testutil.generateId(blobNamesPrefix, blobNames, suite.isMocked);
+    var blobText = '<html><h1>THIS IS HTML</h1></html>';
+    var contentType = 'text/html';
+    var options = {
+      contentSettings: {
+        contentType: contentType
+      }
+    };
+
+    blobService.createBlockBlobFromText(containerName, blobName, blobText, options, function (err) {
+      assert.equal(err, null);
+
+      blobService.getBlobProperties(containerName, blobName, function (error, properties) {
+        assert.equal(error, null);
+        assert.equal(properties.container, containerName);
+        assert.equal(properties.name, blobName);
+        assert.equal(properties.contentSettings.contentType, contentType);
+
+        done();
+      });
+    });
+  });
   
   // This test ensures that blocks can be created from files correctly
   // and was created to ensure that the request module does not magically add

--- a/test/services/blob/blobservice-uploaddownload-tests.js
+++ b/test/services/blob/blobservice-uploaddownload-tests.js
@@ -199,8 +199,24 @@ describe('blob-uploaddownload-tests', function () {
     var blobName = 'blobs/' + testutil.generateId(blobNamesPrefix, blobNames, suite.isMocked);
     var blobText = 'Hello World!';
 
-    // Create the empty page blob
     blobService.createBlockBlobFromText(containerName, blobName, blobText, function (err) {
+      assert.equal(err, null);
+
+      blobService.getBlobProperties(containerName, blobName, function (error, properties) {
+        assert.equal(error, null);
+        assert.equal(properties.container, containerName);
+        assert.equal(properties.name, blobName);
+
+        done();
+      });
+    });
+  });
+
+  it('CreateEmptyBlob', function (done) {
+    var blobName = 'blobs/' + testutil.generateId(blobNamesPrefix, blobNames, suite.isMocked);
+
+    // Create the empty block blob
+    blobService.createBlockBlobFromText(containerName, blobName, null, function (err) {
       assert.equal(err, null);
 
       blobService.getBlobProperties(containerName, blobName, function (error, properties) {

--- a/test/services/blob/blobservice-uploaddownload-tests.js
+++ b/test/services/blob/blobservice-uploaddownload-tests.js
@@ -273,6 +273,13 @@ describe('blob-uploaddownload-tests', function () {
     });
   });
   
+  it('returns correct error when specifying invalid content-length', function (done) {
+    blobService.createBlockFromStream('test', containerName, blockBlobName, rfs.createReadStream(blockFileName), 'invalidlength', function (error) {
+      assert.ok(error.message.indexOf('invalid content length') !== -1);
+      done();
+    });
+  });
+  
   describe('blob-piping-tests', function() {
     runOrSkip('should be able to upload block blob from piped stream', function (done) { 
       var blobName = testutil.generateId(blobNamesPrefix, blobNames, suite.isMocked);

--- a/test/services/file/fileservice-share-tests.js
+++ b/test/services/file/fileservice-share-tests.js
@@ -585,21 +585,21 @@ describe('FileShare', function () {
       var readWriteSharePolicy = {
         AccessPolicy: {
           Permissions: 'rw',
-          Expiry: new Date('2016-10-01')
+          Expiry: new Date('2017-10-01')
         }
       };
       
       var readCreateSharePolicy = {
         AccessPolicy: {
           Permissions: 'rc',
-          Expiry: new Date('2016-10-01')
+          Expiry: new Date('2017-10-01')
         }
       };
 
       var filePolicy = {
         AccessPolicy: {
           Permissions: 'd',
-          Expiry: new Date('2016-10-10')
+          Expiry: new Date('2017-10-10')
         }
       };
       


### PR DESCRIPTION
ALL
* Added `ENOTFOUND` for secondary endpoint and `ECONNREFUSED` to `RetryPolicyFilter`.
* Added support for `text/html` error response body.

BLOB
* Fixed the issue that the ChunkAllocator maxCount is aligned with parallelOperationThreadCount.
* Changed `/S` of SpeedSummary to `/s`.
* Fixed the issue that `BlobService.createBlockBlobFromText` will hang when passed `null` or `undefined` `text` argument. 
* Fixed the issue that `BlobService.createBlockBlobFromText` will always set `content-type` to `text/plain`.

QUEUE
* Allowed `QueueService.peekMessages` against secondary endpoint.

FILE
* Fixed the issue that the ChunkAllocator maxCount is aligned with parallelOperationThreadCount.
* Changed `/S` of SpeedSummary to `/s`.