### PR TITLE
Adding content for queue message encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,10 @@ queueService.getMessages(queueName, function(error, serverMessages) {
   }
 });
 ```
-
+Use below parameter in Queue Service to set encoding. Else, you won't be able to see data in Storage explorer. [#176](https://github.com/Azure/azure-storage-node/issues/176)
+```
+queueService.messageEncoder = new azure.QueueMessageEncoder.TextBase64QueueMessageEncoder();
+```
 ### File Storage
 
 The **createShareIfNotExists** method can be used to create a


### PR DESCRIPTION
Storage Explorer reports error  “Invalid length for a Base-64 char array or string”
![azurestorageexplorer](https://cloud.githubusercontent.com/assets/1486808/21281286/142bafea-c3b1-11e6-829a-c239dc8a43fa.jpg)
