### PR TITLE
Fix Typescript definition for createQueueService()

### DIFF
--- a/typings/azure-storage/azure-storage.d.ts
+++ b/typings/azure-storage/azure-storage.d.ts
@@ -8762,7 +8762,7 @@ declare module azurestorage {
   *                                                     Otherwise 'host.primaryHost' defines the primary host and 'host.secondaryHost' defines the secondary host.
   * @return {QueueService}                              A new QueueService object.
   */
-  export function createQueueService(storageAccount: string, storageAccessKey: string, host: string | StorageHost): QueueService;
+  export function createQueueService(storageAccount: string, storageAccessKey: string, host?: string | StorageHost): QueueService;
   export function createQueueService(connectionString: string): QueueService;
   export function createQueueService(): QueueService;
 


### PR DESCRIPTION
Current definition defines the 3rd parameter as mandatory. This PR fixes this issue by marking this `host` parameter as optional. 