### PR TITLE
Overloaded method createTableService()

### DIFF
--- a/typings/azure-storage/azure-storage.d.ts
+++ b/typings/azure-storage/azure-storage.d.ts
@@ -8649,6 +8649,15 @@ declare module azurestorage {
 
   /**
   * Creates a new {@link TableService} object.
+  * Because no storageaccount or storageaccesskey are provided, the AZURE_STORAGE_CONNECTION_STRING and then the AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_ACCESS_KEY
+  * environment variables will be used.
+  * @return {TableService}                              A new TableService object.
+  *
+  */
+  export function createTableService(): TableService;
+
+  /**
+  * Creates a new {@link TableService} object.
   * If no storageaccount or storageaccesskey are provided, the AZURE_STORAGE_CONNECTION_STRING and then the AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_ACCESS_KEY
   * environment variables will be used.
   *

--- a/typings/azure-storage/azure-storage.d.ts
+++ b/typings/azure-storage/azure-storage.d.ts
@@ -8649,23 +8649,6 @@ declare module azurestorage {
 
   /**
   * Creates a new {@link TableService} object.
-  * Because no storageaccount or storageaccesskey are provided, the AZURE_STORAGE_CONNECTION_STRING and then the AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_ACCESS_KEY
-  * environment variables will be used.
-  * @return {TableService}                              A new TableService object.
-  *
-  */
-  export function createTableService(): TableService;
- 
-  /**
-  * Creates a new {@link TableService} object for given connection string.
-  * @param {string} connectionString
-  * @return {TableService}                              A new TableService object.
-  *
-  */
-  export function createTableService(connectionString: string): TableService;
-
-  /**
-  * Creates a new {@link TableService} object.
   * If no storageaccount or storageaccesskey are provided, the AZURE_STORAGE_CONNECTION_STRING and then the AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_ACCESS_KEY
   * environment variables will be used.
   *

--- a/typings/azure-storage/azure-storage.d.ts
+++ b/typings/azure-storage/azure-storage.d.ts
@@ -8655,6 +8655,14 @@ declare module azurestorage {
   *
   */
   export function createTableService(): TableService;
+ 
+  /**
+  * Creates a new {@link TableService} object for given connection string.
+  * @param {string} connectionString
+  * @return {TableService}                              A new TableService object.
+  *
+  */
+  export function createTableService(connectionString: string): TableService;
 
   /**
   * Creates a new {@link TableService} object.
@@ -8668,7 +8676,9 @@ declare module azurestorage {
   * @return {TableService}                              A new TableService object.
   *
   */
-  export function createTableService(storageAccountOrConnectionString: string, storageAccessKey: string, host: StorageHost): TableService;
+  export function createTableService(): TableService;
+  export function createTableService(connectionString: string): TableService;
+  export function createTableService(storageAccountOrConnectionString: string, storageAccessKey: string, host?: StorageHost): TableService;
 
   /**
   * Creates a new {@link TableService} object using the host Uri and the SAS credentials provided.


### PR DESCRIPTION
Created overload for method createTableService() to support examples without passed params. With current types you have to call it as createTableService(null, null, null) which is not JS/TS convenient.