### PR TITLE
Update queueservice.js

### DIFF
--- a/lib/services/queue/queueservice.js
+++ b/lib/services/queue/queueservice.js
@@ -731,7 +731,7 @@ QueueService.prototype.createMessage = function (queue, messageText, optionsOrCa
   var processResponseCallback = function (responseObject, next) {
     responseObject.queueMessageResults = [];
 
-    if (responseObject.response.body.QueueMessagesList && responseObject.response.body.QueueMessagesList.QueueMessage) {
+    if (responseObject.response && responseObject.response.body && responseObject.response.body.QueueMessagesList && responseObject.response.body.QueueMessagesList.QueueMessage) {
       var messages = responseObject.response.body.QueueMessagesList.QueueMessage;
 
       if (!_.isArray(messages)) {


### PR DESCRIPTION
Fixes #265 - check that `responseObject` _has_ a `response`