### PR TITLE
Fix uses of BlobResult object in sample source code

### DIFF
--- a/examples/samples/blobuploaddownloadsample.js
+++ b/examples/samples/blobuploaddownloadsample.js
@@ -181,7 +181,7 @@ function useAccessCondition(containerName, callback) {
     if (error) {
       console.log(error);
     } else {
-      console.log(' Created the blob ' + blobAccess.blob);
+      console.log(' Created the blob ' + blobAccess.name);
       console.log(' Blob Etag is: ' + blobAccess.etag);
           
       // Use the If-not-match ETag condition to access the blob. By
@@ -190,7 +190,7 @@ function useAccessCondition(containerName, callback) {
       // sample no other client is accessing the blob, so this will fail as
       // expected.
       var options = { accessConditions: { EtagNonMatch: blobAccess.etag} };
-      blobService.createBlockBlobFromText(containerName, blobAccess.blob, 'new hello', options, function (error2) {
+      blobService.createBlockBlobFromText(containerName, blobAccess.name, 'new hello', options, function (error2) {
         if (error2 && error2.statusCode === 412 && error2.code === 'ConditionNotMet') {
           console.log('Attempted to recreate the blob with the if-none-match access condition and got the expected exception.');
           callback();

--- a/examples/samples/blobuploaddownloadsample.js
+++ b/examples/samples/blobuploaddownloadsample.js
@@ -177,20 +177,20 @@ function useAccessCondition(containerName, callback) {
   console.log('Entering useAccessCondition.');
 
   // Create a blob.
-  blobService.createBlockBlobFromText(containerName, blobAccess, 'hello', function (error, blobAccess) {
+  blobService.createBlockBlobFromText(containerName, blobAccess, 'hello', function (error, blobInformation) {
     if (error) {
       console.log(error);
     } else {
-      console.log(' Created the blob ' + blobAccess.name);
-      console.log(' Blob Etag is: ' + blobAccess.etag);
+      console.log(' Created the blob ' + blobInformation.name);
+      console.log(' Blob Etag is: ' + blobInformation.etag);
           
       // Use the If-not-match ETag condition to access the blob. By
       // using the IfNoneMatch condition we are asserting that the blob needs
       // to have been modified in order to complete the request. In this
       // sample no other client is accessing the blob, so this will fail as
       // expected.
-      var options = { accessConditions: { EtagNonMatch: blobAccess.etag} };
-      blobService.createBlockBlobFromText(containerName, blobAccess.name, 'new hello', options, function (error2) {
+      var options = { accessConditions: { EtagNonMatch: blobInformation.etag} };
+      blobService.createBlockBlobFromText(containerName, blobInformation.name, 'new hello', options, function (error2) {
         if (error2 && error2.statusCode === 412 && error2.code === 'ConditionNotMet') {
           console.log('Attempted to recreate the blob with the if-none-match access condition and got the expected exception.');
           callback();


### PR DESCRIPTION
This replace use of `blob` proerty with `name` property for the
BlobResult object in sample source code.

See:
https://github.com/Azure/azure-storage-node/blob/dev/BreakingChanges.md

Use better name for result parameter with blob information
This remove problem with using differently scoped variables in source
code: one for globally (per-module) declared `blobAccess` variable,
the second used as name for result information parameter of
`createBlockBlobFromText` method callback

Thanks!