### PR TITLE
chore(package): update request to 2.81.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "json-edm-parser": "0.1.2",
     "md5.js": "1.3.4",
     "readable-stream": "~2.0.0",
-    "request": "~2.74.0",
+    "request": "~2.81.0",
     "underscore": "~1.8.3",
     "uuid": "^3.0.0",
     "validator": "~3.35.0",


### PR DESCRIPTION
Currently, we pull a version of request that comes with some known-to-be-vulnerable dependency -- see https://snyk.io/test/npm/azure-storage
Trying to address this, bumping request to 2.81.0