### PR TITLE
Added browser specific APIs for uploading files and blobs

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -24,5 +24,9 @@
   "trailing": true,
   "undef": true,
   "unused": true,
-  "shadow": true
+  "shadow": true,
+  "globals": {
+    "FileReader": true,
+    "window": true
+  }
 }

--- a/browser/ChangeLog.md
+++ b/browser/ChangeLog.md
@@ -1,5 +1,16 @@
 Note: This is the change log file for Azure Storage JavaScript Client Library.
 
+2017.07 Version 0.2.2-preview.7
+
+* Added browser specific APIs for blobs and files uploading.
+    * `BlobService.createBlockBlobFromBrowserFile`
+    * `BlobService.createPageBlobFromBrowserFile`
+    * `BlobService.createAppendBlobFromBrowserFile`
+    * `BlobService.appendFromBrowserFile`
+    * `FileService.createFileFromBrowserFile`
+* Updated samples with above new added APIs.
+* Dropped dependency to browserify-fs.
+
 2017.07 Version 0.2.2-preview.6
 
 * Generated browser compatible JavaScript files based on Microsoft Azure Storage SDK for Node.js 2.2.1.

--- a/browser/samples/sample-blob.html
+++ b/browser/samples/sample-blob.html
@@ -158,61 +158,19 @@ blobService.listBlobsSegmented('mycontainer', null, function (error, results) {
 });
 </pre>
             <h3>Upload Blob</h3>
-            <p><code>BlobService</code> provides <code>uploadBlobByStream</code> for uploading a blob from stream.
-               However, currently <code>uploadBlobByStream</code> only accepts a Node.js <code>ReadableStream</code> type which pure JavaScript doesn't provide.
+            <p><code>BlobService</code> provides <code>createBlockBlobFromBrowserFile</code>, <code>createPageBlobFromBrowserFile</code>, <code>createAppendBlobFromBrowserFile</code> and <code>appendFromBrowserFile</code> for uploading or appending a blob from an HTML file in browsers.
             </p>
 
-            <div class="panel panel-primary"> 
-                <div class="panel-body">
-                    <b>Note</b>: After importing <code>azure-storage.common.js</code>, you could require 3 Node.js types: <code>stream</code>, <code>util</code> and <code>buffer</code>, then wrap a ReadableStream based on HTML5 <code>FileReader</code>.
-                </div>
-            </div>
-<pre>
-// Provides a Stream for a file in webpage, inheriting from NodeJS Readable stream.
-var Buffer = require('buffer').Buffer;
-var Stream = require('stream');
-var util = require('util');
-
-function FileStream(file, opt) {
-    Stream.Readable.call(this, opt);
-
-    this.fileReader = new FileReader(file);
-    this.file = file;
-    this.size = file.size;
-    this.chunkSize = 1024 * 1024 * 4; // 4MB
-    this.offset = 0;
-    var _me = this;
-    
-    this.fileReader.onloadend = function loaded(event) {
-        var data = event.target.result;
-        var buf = Buffer.from(data);
-        _me.push(buf);
-    }
-}
-util.inherits(FileStream, Stream.Readable);
-FileStream.prototype._read = function() {
-    if (this.offset > this.size) {
-        this.push(null);
-    } else {
-        var end = this.offset + this.chunkSize;
-        var slice = this.file.slice(this.offset, end);
-        this.fileReader.readAsArrayBuffer(slice);
-        this.offset = end;
-    }
-};
-</pre>
             <p>Uploading blob from stream. You can set up the blob name as well as the size of this uploading session. </p>
 <pre>
 // If one file has been selected in the HTML file input element
-var files = document.getElementById('fileinput').files;
-var file = files[0];
-var fileStream = new FileStream(file);
+var file = document.getElementById('fileinput').files[0];
 
 var customBlockSize = file.size > 1024 * 1024 * 32 ? 1024 * 1024 * 4 : 1024 * 512;
 blobService.singleBlobPutThresholdInBytes = customBlockSize;
 
 var finishedOrError = false;
-var speedSummary = blobService.createBlockBlobFromStream('mycontainer', file.name, fileStream, file.size, {blockSize : customBlockSize}, function(error, result, response) {
+var speedSummary = blobService.createBlockBlobFromBrowserFile('mycontainer', file.name, file, {blockSize : customBlockSize}, function(error, result, response) {
     finishedOrError = true;
     if (error) {
         // Upload blob failed
@@ -317,41 +275,6 @@ blobService.deleteBlobIfExists(container, blob, function(error, result) {
         <!-- azure-storage.common.js also exports Node.js module stream, util and buffer -->
         <script src="../bundle/azure-storage.common.js"></script> 
         <script src="../bundle/azure-storage.blob.js"></script>
-
-        <script>
-            // Provides a Stream for a file in webpage, inheriting from NodeJS Readable stream.
-            var Stream = require('stream');
-            var util = require('util');
-            var Buffer = require('buffer').Buffer;
-
-            function FileStream(file, opt) {
-                Stream.Readable.call(this, opt);
-
-                this.fileReader = new FileReader(file);
-                this.file = file;
-                this.size = file.size;
-                this.chunkSize = 1024 * 1024 * 4; // 4MB
-                this.offset = 0;
-                var _me = this;
-                
-                this.fileReader.onloadend = function loaded(event) {
-                    var data = event.target.result;
-                    var buf = Buffer.from(data);
-                    _me.push(buf);
-                }
-            }
-            util.inherits(FileStream, Stream.Readable);
-            FileStream.prototype._read = function() {
-                if (this.offset > this.size) {
-                    this.push(null);
-                } else {
-                    var end = this.offset + this.chunkSize;
-                    var slice = this.file.slice(this.offset, end);
-                    this.fileReader.readAsArrayBuffer(slice);
-                    this.offset = end;
-                }
-            };
-        </script>
 
         <script>
             var account = document.getElementById('account').value;
@@ -546,8 +469,6 @@ blobService.deleteBlobIfExists(container, blob, function(error, result) {
                 btn.disabled = true;
                 btn.innerHTML = "Uploading";
 
-                var fileStream = new FileStream(file);
-
                 // Make a smaller block size when uploading small blobs
                 var blockSize = file.size > 1024 * 1024 * 32 ? 1024 * 1024 * 4 : 1024 * 512;
                 var options = {
@@ -557,7 +478,7 @@ blobService.deleteBlobIfExists(container, blob, function(error, result) {
                 blobService.singleBlobPutThresholdInBytes = blockSize;
 
                 var finishedOrError = false;
-                var speedSummary = blobService.createBlockBlobFromStream(container, file.name, fileStream, file.size, options, function(error, result, response) {
+                var speedSummary = blobService.createBlockBlobFromBrowserFile(container, file.name, file, options, function(error, result, response) {
                     finishedOrError = true;
                     btn.disabled = false;
                     btn.innerHTML = "UploadBlob";

--- a/browser/samples/sample-file.html
+++ b/browser/samples/sample-file.html
@@ -176,57 +176,17 @@ fileService.deleteDirectoryIfExists('myfileshare', 'mydirectory', function(error
 </pre>
 
             <h3>Upload File</h3>
-            <p><code>FileService</code> provides <code>createFileFromStream</code> for uploading a file from stream.
-               However, currently <code>createFileFromStream</code> only accepts a Node.js <code>ReadableStream</code> type which pure JavaScript doesn't provide.
+            <p><code>FileService</code> provides <code>createFileFromBrowserFile</code> for uploading a file from an HTML file in browsers.
             </p>
-            <div class="panel panel-primary"> 
-                <div class="panel-body">
-                    <b>Note</b>: After importing <code>azure-storage.common.js</code>, you could require 3 Node.js types: <code>stream</code>, <code>util</code> and <code>buffer</code>, then wrap a ReadableStream based on HTML5 <code>FileReader</code>.
-                </div>
-            </div>
-<pre>
-// Provides a Stream for a file in webpage, inheriting from NodeJS Readable stream.
-var Stream = require('stream');
-var util = require('util');
-var Buffer = require('buffer').Buffer;
 
-function FileStream(file, opt) {
-    Stream.Readable.call(this, opt);
-
-    this.fileReader = new FileReader(file);
-    this.file = file;
-    this.size = file.size;
-    this.chunkSize = 1024 * 1024 * 4; // 4MB
-    this.offset = 0;
-    var _me = this;
-    
-    this.fileReader.onloadend = function loaded(event) {
-        var data = event.target.result;
-        var buf = Buffer.from(data);
-        _me.push(buf);
-    }
-}
-util.inherits(FileStream, Stream.Readable);
-FileStream.prototype._read = function() {
-    if (this.offset > this.size) {
-        this.push(null);
-    } else {
-        var end = this.offset + this.chunkSize;
-        var slice = this.file.slice(this.offset, end);
-        this.fileReader.readAsArrayBuffer(slice);
-        this.offset = end;
-    }
-};
-</pre>
             <p>Uploading file from stream. You can set up the file name as well as the size of this uploading session. </p>
 <pre>
 // If one file has been selected in the HTML file input element
 var files = document.getElementById('fileinput').files;
 var file = files[0];
-var fileStream = new FileStream(file);
 
 var finishedOrError = false;
-var speedSummary = fileService.createFileFromStream('myfileshare', 'mydirectory', file.name, fileStream, file.size, {}, function(error, result, response) {
+var speedSummary = fileService.createFileFromBrowserFile('myfileshare', 'mydirectory', file.name, file, {}, function(error, result, response) {
     finishedOrError = true;
     if (error) {
         // Upload file failed
@@ -315,42 +275,6 @@ fileService.deleteFileIfExists('myfileshare', 'mydirectory', 'myfile', function(
 
         <script src="../bundle/azure-storage.common.js"></script> 
         <script src="../bundle/azure-storage.file.js"></script>
-
-        <script>
-            // Provides a Stream for a file in webpage, inheriting from NodeJS Readable stream.
-            var Stream = require('stream');
-            var util = require('util');
-            var Buffer = require('buffer').Buffer;
-
-            function FileStream(file, opt) {
-                Stream.Readable.call(this, opt);
-
-                this.fileReader = new FileReader(file);
-                this.file = file;
-                this.size = file.size;
-                this.chunkSize = 1024 * 1024 * 4; // 4MB
-                this.offset = 0;
-                var _me = this;
-                
-                this.fileReader.onloadend = function loaded(event) {
-                    var data = event.target.result;
-                    var buf = Buffer.from(data);
-                    _me.push(buf);
-                }
-            }
-            util.inherits(FileStream, Stream.Readable);
-            FileStream.prototype._read = function() {
-                if (this.offset > this.size) {
-                    console.log('FileStream reaches file end');
-                    this.push(null);
-                } else {
-                    var end = this.offset + this.chunkSize;
-                    var slice = this.file.slice(this.offset, end);
-                    this.fileReader.readAsArrayBuffer(slice);
-                    this.offset = end;
-                }
-            };
-        </script>
 
         <script>
             var account = document.getElementById('account').value;
@@ -624,7 +548,6 @@ fileService.deleteFileIfExists('myfileshare', 'mydirectory', 'myfile', function(
                 btn.disabled = true;
                 btn.innerHTML = "Uploading";
                 var finishedOrError = false;
-                var fileStream = new FileStream(file);
                 var options = {
                     contentSettings: {
                         contentType: file.type
@@ -632,7 +555,7 @@ fileService.deleteFileIfExists('myfileshare', 'mydirectory', 'myfile', function(
                     storeFileContentMD5 : checkMD5
                 };
 
-                var speedSummary = fileService.createFileFromStream(fileShare, currentPath.join('\\\\'), file.name, fileStream, file.size, options, function(error, result, response) {
+                var speedSummary = fileService.createFileFromBrowserFile(fileShare, currentPath.join('\\\\'), file.name, file, options, function(error, result, response) {
                     finishedOrError = true;
                     btn.disabled = false;
                     btn.innerHTML = "Upload";

--- a/lib/common/common.browser.js
+++ b/lib/common/common.browser.js
@@ -16,4 +16,6 @@
 
 var azureCommon = require('./common.core');
 
+azureCommon.BrowserFileReadStream = require('./streams/browserfilereadstream');
+
 module.exports = azureCommon;

--- a/lib/common/streams/batchoperation.js
+++ b/lib/common/streams/batchoperation.js
@@ -29,6 +29,7 @@ var ArgumentError = errors.ArgumentError;
 var DEFAULT_OPERATION_MEMORY_USAGE = Constants.BlobConstants.DEFAULT_WRITE_BLOCK_SIZE_IN_BYTES;
 var DEFAULT_CRITICAL_MEMORY_LIMITATION_32_IN_BYTES = Constants.BlobConstants.DEFAULT_CRITICAL_MEMORY_LIMITATION_32_IN_BYTES;
 var DEFAULT_CRITICAL_MEMORY_LIMITATION_BROWSER_IN_BYTES = Constants.BlobConstants.DEFAULT_CRITICAL_MEMORY_LIMITATION_BROWSER_IN_BYTES;
+var DEFAULT_MINIMUM_MEMORY_USAGE_BROWSER_IN_BYTES = Constants.BlobConstants.DEFAULT_MINIMUM_MEMORY_USAGE_BROWSER_IN_BYTES;
 var DEFAULT_GLOBAL_CONCURRENCY = 5; //Default http connection limitation for nodejs
 
 var SystemTotalMemory = os.totalmem();
@@ -114,14 +115,14 @@ BatchOperation.prototype.IsWorkloadHeavy = function() {
   if(this.enableReuseSocket && !this.callInOrder) {
     sharedRequest = 2;
   }
-  return this._activeOperation >= sharedRequest * this.concurrency ||this._isLowMemory();
+  return this._activeOperation >= sharedRequest * this.concurrency || this._isLowMemory();
 };
 
 /**
 * Get the approximate memory usage for batch operation.
 */
 BatchOperation.prototype._getApproximateMemoryUsage = function() {
-  var currentUsage = azureutil.isBrowser() ? 0 : process.memoryUsage().rss; // Currently, we cannot get memory usage in browsers
+  var currentUsage = azureutil.isBrowser() ? DEFAULT_MINIMUM_MEMORY_USAGE_BROWSER_IN_BYTES : process.memoryUsage().rss; // Currently, we cannot get memory usage in browsers
   var futureUsage = this._queuedOperation * this.operationMemoryUsage;
   return currentUsage + futureUsage;
 };

--- a/lib/common/streams/browserfilereadstream.js
+++ b/lib/common/streams/browserfilereadstream.js
@@ -1,0 +1,61 @@
+// 
+// Copyright (c) Microsoft and contributors.  All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// 
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+
+var buffer = require('buffer').Buffer;
+var stream = require('stream');
+var util = require('util');
+
+var Constants = require('../util/constants');
+var bufferSize = Constants.BlobConstants.DEFAULT_WRITE_BLOCK_SIZE_IN_BYTES;
+
+function BrowserFileReadStream(file, options) {
+  stream.Readable.call(this, options);
+
+  if (!options) {
+    options = {};
+  }
+
+  this._fileReader = new FileReader(file); // HTML FileReader
+  this._file = file;
+  this._size = file.size;
+  this._highWaterMark = options.highWaterMark || bufferSize;
+  this._offset = 0;
+  var self = this;
+
+  this._fileReader.onloadend = function (event) {
+    var data = event.target.result;
+    var buf = buffer.from(data);
+    self.push(buf);
+  };
+
+  this._fileReader.onerror = function (error) {
+    self.emit('error', error);
+  };
+}
+util.inherits(BrowserFileReadStream, stream.Readable);
+
+BrowserFileReadStream.prototype._read = function() {
+  if (this._offset >= this._size) {
+    this.push(null);
+  } else {
+    var end = this._offset + this._highWaterMark;
+    var slice = this._file.slice(this._offset, end);
+    this._fileReader.readAsArrayBuffer(slice);
+    this._offset = end;
+  }
+};
+
+module.exports = BrowserFileReadStream;

--- a/lib/common/streams/chunkstream.js
+++ b/lib/common/streams/chunkstream.js
@@ -17,6 +17,7 @@
 var stream = require('stream');
 var util = require('util');
 
+var azureutil = require('../util/util');
 var Md5Wrapper = require('../md5-wrapper');
 var Constants = require('../util/constants');
 var bufferSize = Constants.BlobConstants.DEFAULT_WRITE_BLOCK_SIZE_IN_BYTES;
@@ -116,7 +117,7 @@ ChunkStream.prototype.error = function () {
 ChunkStream.prototype.destroy = function () {
   this.writable = this.readable = false;
 
-  if (this._allocator && this._allocator.destroy) {
+  if (this._allocator && azureutil.objectIsFunction(this._allocator.destroy)) {
     this._allocator.destroy();
   }
   
@@ -272,7 +273,7 @@ ChunkStream.prototype._popInternalBuffer = function () {
 */
 ChunkStream.prototype._allocateNewBuffer = function() {
   var size = this._highWaterMark;
-  if(this._allocator && this._allocator.getBuffer) {
+  if(this._allocator && azureutil.objectIsFunction(this._allocator.getBuffer)) {
     return this._allocator.getBuffer(size);
   } else {
     var buffer = new Buffer(size);

--- a/lib/common/util/constants.js
+++ b/lib/common/util/constants.js
@@ -534,6 +534,14 @@ var Constants = {
     */
     DEFAULT_CRITICAL_MEMORY_LIMITATION_BROWSER_IN_BYTES: 1 * 1024 * 1024 * 1024,
 
+   /**
+    * The default minimum memory usage in browser environment, in bytes.
+    *
+    * @const
+    * @type {int}
+    */
+    DEFAULT_MINIMUM_MEMORY_USAGE_BROWSER_IN_BYTES: 4 * 1024 * 1024,
+
     /**
     * The maximum size of a single block of block blob.
     *

--- a/lib/common/util/util.js
+++ b/lib/common/util/util.js
@@ -61,6 +61,22 @@ exports.isBrowser = function () {
 };
 
 /**
+* Checks if in IE.
+*
+* @return {bool} True if in IE, false otherwise.
+*/
+exports.isIE = function () {
+  if (!exports.isBrowser()) {
+    return false;
+  }
+
+  var ua = window.navigator.userAgent;
+  var msie = ua.indexOf('MSIE ');
+  var trident = ua.indexOf('Trident/');
+  return msie > 0 || trident > 0;
+};
+
+/**
 * Checks if in a 32bit Node.js environment.
 *
 * @return {bool} True if in a 32bit Node.js environment, false otherwise.

--- a/lib/common/util/validate.js
+++ b/lib/common/util/validate.js
@@ -316,6 +316,33 @@ exports.tableNameIsValid = function (table, callback) {
 };
 
 /**
+* Validates an HTML File object.
+*
+* @param {File} browserFile  The HTML File object.
+*/
+exports.browserFileIsValid = function (browserFile, callback) {
+  var fail;
+
+  initCallback(callback, function (f, cb) {
+    fail = f;
+    callback = cb;
+  });
+
+  // IE doesn't support File.constructor.name
+  if (!azureutil.isBrowser() ||
+    !browserFile ||
+    !browserFile.constructor ||
+    (!azureutil.isIE() && !browserFile.constructor.name) ||
+    (!azureutil.isIE() && browserFile.constructor.name !== 'File' && browserFile.constructor.name !== 'Blob') ||
+    !azureutil.objectIsInt(browserFile.size)) {
+    return fail(new ArgumentError('type', 'Invalid HTML File object.'));
+  } else {
+    callback();
+    return true;
+  }
+};
+
+/**
 * Validates page ranges.
 *
 * @param {int} rangeStart             The range starting position.
@@ -479,6 +506,7 @@ _.extend(ArgumentValidator.prototype, {
   },
 
   tableNameIsValid: exports.tableNameIsValid,
+  browserFileIsValid: exports.browserFileIsValid,
   containerNameIsValid: exports.containerNameIsValid,
   shareNameIsValid: exports.shareNameIsValid,
   blobNameIsValid: exports.blobNameIsValid,

--- a/lib/services/blob/blobservice.browser.js
+++ b/lib/services/blob/blobservice.browser.js
@@ -15,5 +15,305 @@
 // 
 
 var BlobService = require('./blobservice.core');
+var azureCommon = require('./../../common/common.browser');
+var extend = require('extend');
+var mime = require('browserify-mime');
+
+var Constants = azureCommon.Constants;
+var azureutil = azureCommon.util;
+var BlobConstants = Constants.BlobConstants;
+var BrowserFileReadStream = azureCommon.BrowserFileReadStream;
+var SpeedSummary = azureCommon.SpeedSummary;
+var validate = azureCommon.validate;
+
+/**
+* Creates a new block blob. If the blob already exists on the service, it will be overwritten.
+* To avoid overwriting and instead throw an error if the blob exists, please pass in an accessConditions parameter in the options object.
+* (Only available in the JavaScript Client Library for Browsers)
+*
+* @this {BlobService}
+* @param {string}             container                                     The container name.
+* @param {string}             blob                                          The blob name.
+* @param {File}               browserFile                                   The File object to be uploaded created by HTML File API.
+* @param {object}             [options]                                     The request options.
+* @param {int}                [options.blockSize]                           The size of each block. Maximum is 100MB.
+* @param {string}             [options.blockIdPrefix]                       The prefix to be used to generate the block id.
+* @param {string}             [options.leaseId]                             The lease identifier.
+* @param {string}             [options.transactionalContentMD5]             The MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
+* @param {object}             [options.metadata]                            The metadata key/value pairs.
+* @param {int}                [options.parallelOperationThreadCount]        The number of parallel operations that may be performed when uploading.
+* @param {bool}               [options.storeBlobContentMD5]                 Specifies whether the blob's ContentMD5 header should be set on uploads. The default value is true for block blobs.
+* @param {object}             [options.contentSettings]                     The content settings of the blob.
+* @param {string}             [options.contentSettings.contentType]         The MIME content type of the blob. The default type is application/octet-stream.
+* @param {string}             [options.contentSettings.contentEncoding]     The content encodings that have been applied to the blob.
+* @param {string}             [options.contentSettings.contentLanguage]     The natural languages used by this resource.
+* @param {string}             [options.contentSettings.cacheControl]        The Blob service stores this value but does not use or modify it.
+* @param {string}             [options.contentSettings.contentDisposition]  The blob's content disposition.
+* @param {string}             [options.contentSettings.contentMD5]          The blob's MD5 hash.
+* @param {AccessConditions}   [options.accessConditions]                    The access conditions.
+* @param {LocationMode}       [options.locationMode]                        Specifies the location mode used to decide which location the request should be sent to. 
+*                                                                           Please see StorageUtilities.LocationMode for the possible values.
+* @param {int}                [options.timeoutIntervalInMs]                 The server timeout interval, in milliseconds, to use for the request.
+* @param {int}                [options.clientRequestTimeoutInMs]            The timeout of client requests, in milliseconds, to use for the request.
+* @param {int}                [options.maximumExecutionTimeInMs]            The maximum execution time, in milliseconds, across all potential retries, to use when making this request.
+*                                                                           The maximum execution time interval begins at the time that the client begins building the request. The maximum
+*                                                                           execution time is checked intermittently while performing requests, and before executing retries.
+* @param {string}             [options.clientRequestId]                     A string that represents the client request ID with a 1KB character limit.
+* @param {bool}               [options.useNagleAlgorithm]                   Determines whether the Nagle algorithm is used; true to use the Nagle algorithm; otherwise, false.
+*                                                                           The default value is false.
+* @param {errorOrResult}      callback                                      `error` will contain information
+*                                                                           if an error occurs; otherwise `[result]{@link BlobResult}` will contain
+*                                                                           the blob information.
+*                                                                           `response` will contain information related to this operation.
+* @return {SpeedSummary}
+*/
+BlobService.prototype.createBlockBlobFromBrowserFile = function (container, blob, browserFile, optionsOrCallback, callback) {
+  return this._createBlobFromBrowserFile(container, blob, BlobConstants.BlobTypes.BLOCK, browserFile, optionsOrCallback, callback);
+};
+
+/**
+* Uploads a page blob from an HTML file. If the blob already exists on the service, it will be overwritten.
+* To avoid overwriting and instead throw an error if the blob exists, please pass in an accessConditions parameter in the options object.
+* (Only available in the JavaScript Client Library for Browsers)
+*
+* @this {BlobService}
+* @param {string}             container                                           The container name.
+* @param {string}             blob                                                The blob name.
+* @param {File}               browserFile                                         The File object to be uploaded created by HTML File API.
+* @param {object}             [options]                                           The request options.
+* @param {SpeedSummary}       [options.speedSummary]                              The upload tracker objects.
+* @param {int}                [options.parallelOperationThreadCount]              The number of parallel operations that may be performed when uploading.
+* @param {string}             [options.leaseId]                                   The lease identifier.
+* @param {string}             [options.transactionalContentMD5]                   An MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
+* @param {object}             [options.metadata]                                  The metadata key/value pairs.
+* @param {bool}               [options.storeBlobContentMD5]                       Specifies whether the blob's ContentMD5 header should be set on uploads. 
+*                                                                                 The default value is false for page blobs.
+* @param {bool}               [options.useTransactionalMD5]                       Calculate and send/validate content MD5 for transactions.
+* @param {object}             [options.contentSettings]                           The content settings of the blob.
+* @param {string}             [options.contentSettings.contentType]               The MIME content type of the blob. The default type is application/octet-stream.
+* @param {string}             [options.contentSettings.contentEncoding]           The content encodings that have been applied to the blob.
+* @param {string}             [options.contentSettings.contentLanguage]           The natural languages used by this resource.
+* @param {string}             [options.contentSettings.cacheControl]              The Blob service stores this value but does not use or modify it.
+* @param {string}             [options.contentSettings.contentDisposition]        The blob's content disposition.
+* @param {string}             [options.contentSettings.contentMD5]                The blob's MD5 hash.
+* @param {AccessConditions}   [options.accessConditions]                          The access conditions.
+* @param {LocationMode}       [options.locationMode]                              Specifies the location mode used to decide which location the request should be sent to. 
+*                                                                                 Please see StorageUtilities.LocationMode for the possible values.
+* @param {int}                [options.timeoutIntervalInMs]                       The server timeout interval, in milliseconds, to use for the request.
+* @param {int}                [options.clientRequestTimeoutInMs]                  The timeout of client requests, in milliseconds, to use for the request.
+* @param {int}                [options.maximumExecutionTimeInMs]                  The maximum execution time, in milliseconds, across all potential retries, to use when making this request.
+*                                                                                 The maximum execution time interval begins at the time that the client begins building the request. The maximum
+*                                                                                 execution time is checked intermittently while performing requests, and before executing retries.
+* @param {string}             [options.clientRequestId]                           A string that represents the client request ID with a 1KB character limit.
+* @param {bool}               [options.useNagleAlgorithm]                         Determines whether the Nagle algorithm is used; true to use the Nagle algorithm; otherwise, false.
+*                                                                                 The default value is false.
+* @param {errorOrResult}      callback                                            `error` will contain information
+*                                                                                 if an error occurs; otherwise `[result]{@link BlobResult}` will contain
+*                                                                                 the blob information.
+*                                                                                 `response` will contain information related to this operation.
+* @return {SpeedSummary}
+*/
+BlobService.prototype.createPageBlobFromBrowserFile = function (container, blob, browserFile, optionsOrCallback, callback) {
+  return this._createBlobFromBrowserFile(container, blob, BlobConstants.BlobTypes.PAGE, browserFile, optionsOrCallback, callback);
+};
+
+/**
+* Creates a new append blob from an HTML File object. If the blob already exists on the service, it will be overwritten.
+* To avoid overwriting and instead throw an error if the blob exists, please pass in an accessConditions parameter in the options object.
+* This API should be used strictly in a single writer scenario because the API internally uses the append-offset conditional header to avoid duplicate blocks.
+* If you are guaranteed to have a single writer scenario, please look at options.absorbConditionalErrorsOnRetry and see if setting this flag to true is acceptable for you.
+* If you want to append data to an already existing blob, please look at appendFromBrowserFile.
+* (Only available in the JavaScript Client Library for Browsers)
+*
+* @this {BlobService}
+* @param {string}             container                                     The container name.
+* @param {string}             blob                                          The blob name.
+* @param {File}               browserFile                                   The File object to be uploaded created by HTML File API.
+* @param {object}             [options]                                     The request options.
+* @param {bool}               [options.absorbConditionalErrorsOnRetry]      Specifies whether to absorb the conditional error on retry.
+* @param {string}             [options.leaseId]                             The lease identifier. 
+* @param {object}             [options.metadata]                            The metadata key/value pairs.
+* @param {bool}               [options.storeBlobContentMD5]                 Specifies whether the blob's ContentMD5 header should be set on uploads. The default value is true for block blobs.
+* @param {bool}               [options.useTransactionalMD5]                 Calculate and send/validate content MD5 for transactions.
+* @param {object}             [options.contentSettings]                     The content settings of the blob.
+* @param {string}             [options.contentSettings.contentType]         The MIME content type of the blob. The default type is application/octet-stream.
+* @param {string}             [options.contentSettings.contentEncoding]     The content encodings that have been applied to the blob.
+* @param {string}             [options.contentSettings.contentLanguage]     The natural languages used by this resource.
+* @param {string}             [options.contentSettings.cacheControl]        The Blob service stores this value but does not use or modify it.
+* @param {string}             [options.contentSettings.contentDisposition]  The blob's content disposition.
+* @param {string}             [options.contentSettings.contentMD5]          The blob's MD5 ahash.
+* @param {AccessConditions}   [options.accessConditions]                    The access conditions.
+* @param {LocationMode}       [options.locationMode]                        Specifies the location mode used to decide which location the request should be sent to. 
+*                                                                           Please see StorageUtilities.LocationMode for the possible values.
+* @param {int}                [options.timeoutIntervalInMs]                 The server timeout interval, in milliseconds, to use for the request.
+* @param {int}                [options.clientRequestTimeoutInMs]            The timeout of client requests, in milliseconds, to use for the request.
+* @param {int}                [options.maximumExecutionTimeInMs]            The maximum execution time, in milliseconds, across all potential retries, to use when making this request.
+*                                                                           The maximum execution time interval begins at the time that the client begins building the request. The maximum
+*                                                                           execution time is checked intermittently while performing requests, and before executing retries.
+* @param {string}             [options.clientRequestId]                     A string that represents the client request ID with a 1KB character limit.
+* @param {bool}               [options.useNagleAlgorithm]                   Determines whether the Nagle algorithm is used; true to use the Nagle algorithm; otherwise, false.
+*                                                                           The default value is false.
+* @param {errorOrResult}      callback                                      `error` will contain information
+*                                                                           if an error occurs; otherwise `[result]{@link BlobResult}` will contain
+*                                                                           the blob information.
+*                                                                           `response` will contain information related to this operation.
+* @return {SpeedSummary}
+*/
+BlobService.prototype.createAppendBlobFromBrowserFile = function (container, blob, browserFile, optionsOrCallback, callback) {
+  return this._createBlobFromBrowserFile(container, blob, BlobConstants.BlobTypes.APPEND, browserFile, optionsOrCallback, callback);
+};
+
+/**
+* Appends to an append blob from an HTML File object. Assumes the blob already exists on the service.
+* This API should be used strictly in a single writer scenario because the API internally uses the append-offset conditional header to avoid duplicate blocks.
+* If you are guaranteed to have a single writer scenario, please look at options.absorbConditionalErrorsOnRetry and see if setting this flag to true is acceptable for you.
+* (Only available in the JavaScript Client Library for Browsers)
+*
+* @this {BlobService}
+* @param {string}             container                                     The container name.
+* @param {string}             blob                                          The blob name.
+* @param {File}               browserFile                                   The File object to be uploaded created by HTML File API.
+* @param {object}             [options]                                     The request options.
+* @param {bool}               [options.absorbConditionalErrorsOnRetry]      Specifies whether to absorb the conditional error on retry.
+* @param {string}             [options.leaseId]                             The lease identifier.
+* @param {object}             [options.metadata]                            The metadata key/value pairs.
+* @param {object}             [options.contentSettings]                     The content settings of the blob.
+* @param {string}             [options.contentSettings.contentType]         The MIME content type of the blob. The default type is application/octet-stream.
+* @param {string}             [options.contentSettings.contentEncoding]     The content encodings that have been applied to the blob.
+* @param {string}             [options.contentSettings.contentLanguage]     The natural languages used by this resource.
+* @param {string}             [options.contentSettings.cacheControl]        The Blob service stores this value but does not use or modify it.
+* @param {string}             [options.contentSettings.contentDisposition]  The blob's content disposition.
+* @param {string}             [options.contentSettings.contentMD5]          The blob's MD5 hash.
+* @param {AccessConditions}   [options.accessConditions]                    The access conditions.
+* @param {LocationMode}       [options.locationMode]                        Specifies the location mode used to decide which location the request should be sent to. 
+*                                                                           Please see StorageUtilities.LocationMode for the possible values.
+* @param {int}                [options.timeoutIntervalInMs]                 The server timeout interval, in milliseconds, to use for the request.
+* @param {int}                [options.clientRequestTimeoutInMs]            The timeout of client requests, in milliseconds, to use for the request.
+* @param {int}                [options.maximumExecutionTimeInMs]            The maximum execution time, in milliseconds, across all potential retries, to use when making this request.
+*                                                                           The maximum execution time interval begins at the time that the client begins building the request. The maximum
+*                                                                           execution time is checked intermittently while performing requests, and before executing retries.
+* @param {string}             [options.clientRequestId]                     A string that represents the client request ID with a 1KB character limit.
+* @param {bool}               [options.useNagleAlgorithm]                   Determines whether the Nagle algorithm is used; true to use the Nagle algorithm; otherwise, false.
+*                                                                           The default value is false.
+* @param {errorOrResult}      callback                                      `error` will contain information
+*                                                                           if an error occurs; otherwise `[result]{@link BlobResult}` will contain
+*                                                                           the blob information.
+*                                                                           `response` will contain information related to this operation.
+* @return {SpeedSummary}
+*/
+BlobService.prototype.appendFromBrowserFile = function (container, blob, browserFile, optionsOrCallback, callback) {
+  var userOptions;
+  azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { userOptions = o; callback = c; });
+  
+  validate.validateArgs('appendFromBrowserFile', function (v) {
+    v.string(container, 'container');
+    v.string(blob, 'blob');
+    v.containerNameIsValid(container);
+    v.browserFileIsValid(browserFile);
+    v.callback(callback);
+  });
+  
+  var options = extend(true, {}, userOptions);
+  options.speedSummary = options.speedSummary || new SpeedSummary(blob);  
+
+  var stream = new BrowserFileReadStream(browserFile);
+  var streamCallback = function (appendError, blob, response) {
+    if (azureutil.objectIsFunction(stream.destroy)) {
+        stream.destroy();
+    }
+    callback(appendError, blob, response);
+  };
+  this._uploadBlobFromStream(false, container, blob, BlobConstants.BlobTypes.APPEND, stream, browserFile.size, options, streamCallback);
+
+  return options.speedSummary;
+};
+
+// Private methods
+
+/**
+* Creates a new blob (Block/Page/Append). If the blob already exists on the service, it will be overwritten.
+* To avoid overwriting and instead throw an error if the blob exists, please pass in an accessConditions parameter in the options object.
+* (Only available in the JavaScript Client Library for Browsers)
+*
+* @ignore
+*
+* @this {BlobService}
+* @param {string}             container                                     The container name.
+* @param {string}             blob                                          The blob name.
+* @param {BlobType}           blobType                                      The blob type.
+* @param {File}               browserFile                                   The File object to be uploaded created by HTML File API.
+* @param {object}             [options]                                     The request options.
+* @param {bool}               [options.absorbConditionalErrorsOnRetry]      Specifies whether to absorb the conditional error on retry. (For append blob only)
+* @param {int}                [options.blockSize]                           The size of each block. Maximum is 100MB.
+* @param {string}             [options.blockIdPrefix]                       The prefix to be used to generate the block id. (For block blob only)
+* @param {string}             [options.leaseId]                             The lease identifier.
+* @param {string}             [options.transactionalContentMD5]             An MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
+* @param {object}             [options.metadata]                            The metadata key/value pairs.
+* @param {int}                [options.parallelOperationThreadCount]        The number of parallel operations that may be performed when uploading.
+* @param {bool}               [options.storeBlobContentMD5]                 Specifies whether the blob's ContentMD5 header should be set on uploads. The default value is true for block blobs.
+* @param {object}             [options.contentSettings]                     The content settings of the blob.
+* @param {string}             [options.contentSettings.contentType]         The MIME content type of the blob. The default type is application/octet-stream.
+* @param {string}             [options.contentSettings.contentEncoding]     The content encodings that have been applied to the blob.
+* @param {string}             [options.contentSettings.contentLanguage]     The natural languages used by this resource.
+* @param {string}             [options.contentSettings.cacheControl]        The Blob service stores this value but does not use or modify it.
+* @param {string}             [options.contentSettings.contentDisposition]  The blob's content disposition.
+* @param {string}             [options.contentSettings.contentMD5]          The MD5 hash of the blob content.
+* @param {AccessConditions}   [options.accessConditions]                    The access conditions.
+* @param {LocationMode}       [options.locationMode]                        Specifies the location mode used to decide which location the request should be sent to. 
+*                                                                           Please see StorageUtilities.LocationMode for the possible values.
+* @param {int}                [options.timeoutIntervalInMs]                 The server timeout interval, in milliseconds, to use for the request.
+* @param {int}                [options.clientRequestTimeoutInMs]            The timeout of client requests, in milliseconds, to use for the request.
+* @param {int}                [options.maximumExecutionTimeInMs]            The maximum execution time, in milliseconds, across all potential retries, to use when making this request.
+*                                                                           The maximum execution time interval begins at the time that the client begins building the request. The maximum
+*                                                                           execution time is checked intermittently while performing requests, and before executing retries.
+* @param {string}             [options.clientRequestId]                     A string that represents the client request ID with a 1KB character limit.
+* @param {bool}               [options.useNagleAlgorithm]                   Determines whether the Nagle algorithm is used; true to use the Nagle algorithm; otherwise, false.
+*                                                                           The default value is false.
+* @param {errorOrResult}      callback                                      The callback function.
+*
+* @return {SpeedSummary}
+*
+*/
+BlobService.prototype._createBlobFromBrowserFile = function (container, blob, blobType, browserFile, optionsOrCallback, callback) {
+  var userOptions;
+  azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { userOptions = o; callback = c; });
+  
+  validate.validateArgs('_createBlobFromBrowserFile', function (v) {
+    v.string(container, 'container');
+    v.string(blob, 'blob');
+    v.containerNameIsValid(container);
+    v.blobTypeIsValid(blobType);
+    v.browserFileIsValid(browserFile);
+    v.callback(callback);
+  });
+  
+  var options = extend(true, {}, userOptions);
+  options.speedSummary = options.speedSummary || new SpeedSummary(blob);
+  
+  var self = this;
+  var creationCallback = function (createError, createBlob, createResponse) {
+    if (createError) {
+      callback(createError, createBlob, createResponse);
+    } else {
+      // Automatically detect the mime type
+      if(azureutil.tryGetValueChain(options, ['contentSettings','contentType'], undefined) === undefined) {
+        azureutil.setObjectInnerPropertyValue(options, ['contentSettings','contentType'], mime.lookup(browserFile.name));
+      }
+
+      var stream = new BrowserFileReadStream(browserFile);
+      var streamCallback = function (createError, createBlob, createResponse) {
+        if (azureutil.objectIsFunction(stream.destroy)) {
+          stream.destroy();
+        }
+        callback(createError, createBlob, createResponse);
+      };
+      self._uploadBlobFromStream(true, container, blob, blobType, stream, browserFile.size, options, streamCallback);
+    }
+  };
+
+  this._createBlob(container, blob, blobType, browserFile.size, options, creationCallback);
+  
+  return options.speedSummary;
+};
 
 module.exports = BlobService;

--- a/lib/services/blob/blobservice.core.js
+++ b/lib/services/blob/blobservice.core.js
@@ -1614,7 +1614,7 @@ BlobService.prototype.createReadStream = function (container, blob, optionsOrCal
 *                                                                         Set the option to true for small blobs.
 *                                                                         Parallel download and speed summary won't work with this option on.
 * @param {SpeedSummary}       [options.speedSummary]                      The download tracker objects.
-* @param {int}                [options.parallelOperationThreadCount]      Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]      The number of parallel operations that may be performed when uploading.
 * @param {string}             [options.snapshotId]                        The snapshot identifier.
 * @param {string}             [options.leaseId]                           The lease identifier.
 * @param {string}             [options.rangeStart]                        Return only the bytes of the blob in the specified range.
@@ -2357,7 +2357,7 @@ BlobService.prototype.createPageBlob = function (container, blob, length, option
 * @param {int}                streamLength                                  The length of the stream to upload.
 * @param {object}             [options]                                     The request options.
 * @param {SpeedSummary}       [options.speedSummary]                        The download tracker objects;
-* @param {int}                [options.parallelOperationThreadCount]        Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]        The number of parallel operations that may be performed when uploading.
 * @param {string}             [options.leaseId]                             The lease identifier.
 * @param {string}             [options.transactionalContentMD5]             An MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
 * @param {object}             [options.metadata]                            The metadata key/value pairs.
@@ -2403,7 +2403,7 @@ BlobService.prototype.createPageBlobFromStream = function (container, blob, stre
 * @param {string}             [options.leaseId]                             The lease identifier.
 * @param {string}             [options.transactionalContentMD5]             The MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
 * @param {object}             [options.metadata]                            The metadata key/value pairs.
-* @param {int}                [options.parallelOperationThreadCount]        Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]        The number of parallel operations that may be performed when uploading.
 * @param {bool}               [options.storeBlobContentMD5]                 Specifies whether the blob's ContentMD5 header should be set on uploads. 
 *                                                                           The default value is false for page blobs and true for block blobs.
 * @param {bool}               [options.useTransactionalMD5]                 Calculate and send/validate content MD5 for transactions.
@@ -2453,7 +2453,7 @@ BlobService.prototype.createWriteStreamToExistingPageBlob = function (container,
 * @param {string}             [options.leaseId]                             The lease identifier.
 * @param {string}             [options.transactionalContentMD5]             The MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
 * @param {object}             [options.metadata]                            The metadata key/value pairs.
-* @param {int}                [options.parallelOperationThreadCount]        Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]        The number of parallel operations that may be performed when uploading.
 * @param {bool}               [options.storeBlobContentMD5]                 Specifies whether the blob's ContentMD5 header should be set on uploads. 
 *                                                                           The default value is false for page blobs and true for block blobs.
 * @param {bool}               [options.useTransactionalMD5]                 Calculate and send/validate content MD5 for transactions.
@@ -2956,7 +2956,7 @@ BlobService.prototype.setPageBlobSequenceNumber = function (container, blob, seq
 * @param {string}             [options.leaseId]                             The lease identifier.
 * @param {string}             [options.transactionalContentMD5]             The MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
 * @param {object}             [options.metadata]                            The metadata key/value pairs.
-* @param {int}                [options.parallelOperationThreadCount]        Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]        The number of parallel operations that may be performed when uploading.
 * @param {bool}               [options.storeBlobContentMD5]                 Specifies whether the blob's ContentMD5 header should be set on uploads. The default value is true for block blobs.
 * @param {bool}               [options.useTransactionalMD5]                 Calculate and send/validate content MD5 for transactions.
 * @param {object}             [options.contentSettings]                     The content settings of the blob.
@@ -3041,7 +3041,7 @@ BlobService.prototype.createBlockBlobFromText = function (container, blob, text,
 * @param {string}             [options.leaseId]                             The lease identifier.
 * @param {string}             [options.transactionalContentMD5]             The MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
 * @param {object}             [options.metadata]                            The metadata key/value pairs.
-* @param {int}                [options.parallelOperationThreadCount]        Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]        The number of parallel operations that may be performed when uploading.
 * @param {bool}               [options.storeBlobContentMD5]                 Specifies whether the blob's ContentMD5 header should be set on uploads. 
 *                                                                           The default value is false for page blobs and true for block blobs.
 * @param {bool}               [options.useTransactionalMD5]                 Calculate and send/validate content MD5 for transactions.
@@ -3872,7 +3872,7 @@ BlobService.prototype.appendBlockFromText = function (container, blob, content, 
 * @param {string}             [options.leaseId]                             The lease identifier.
 * @param {string}             [options.transactionalContentMD5]             The MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
 * @param {object}             [options.metadata]                            The metadata key/value pairs.
-* @param {int}                [options.parallelOperationThreadCount]        Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]        The number of parallel operations that may be performed when uploading.
 * @param {bool}               [options.storeBlobContentMD5]                 Specifies whether the blob's ContentMD5 header should be set on uploads. The default value is true for block blobs.
 * @param {bool}               [options.useTransactionalMD5]                 Calculate and send/validate content MD5 for transactions.
 * @param {object}             [options.contentSettings]                     The content settings of the blob.
@@ -4014,7 +4014,7 @@ BlobService.prototype._createBlobFromText = function (container, blob, blobType,
 * @param {string}             [options.leaseId]                             The lease identifier.
 * @param {string}             [options.transactionalContentMD5]             The MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
 * @param {object}             [options.metadata]                            The metadata key/value pairs.
-* @param {int}                [options.parallelOperationThreadCount]        Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]        The number of parallel operations that may be performed when uploading.
 * @param {bool}               [options.storeBlobContentMD5]                 Specifies whether the blob's ContentMD5 header should be set on uploads. 
 *                                                                           The default value is false for page blobs and true for block blobs.
 * @param {bool}               [options.useTransactionalMD5]                 Calculate and send/validate content MD5 for transactions.
@@ -4116,7 +4116,7 @@ BlobService.prototype._createWriteStreamToBlob = function (container, blob, blob
 * @param {string}             [options.leaseId]                             The lease identifier.
 * @param {string}             [options.transactionalContentMD5]             The MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
 * @param {object}             [options.metadata]                            The metadata key/value pairs.
-* @param {int}                [options.parallelOperationThreadCount]        Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]        The number of parallel operations that may be performed when uploading.
 * @param {bool}               [options.storeBlobContentMD5]                 Specifies whether the blob's ContentMD5 header should be set on uploads. The default value is true for block blobs.
 * @param {bool}               [options.useTransactionalMD5]                 Calculate and send/validate content MD5 for transactions.
 * @param {object}             [options.contentSettings]                     The content settings of the blob.
@@ -4155,23 +4155,15 @@ BlobService.prototype._uploadBlobFromStream = function (isNewBlob, container, bl
   var self = this;
   var startUpload = function () {
     var putBlockBlobFromStream = function () {
-      var finalCallback = function (error, result, response) {
-        if (error) {
-          callback(error, result, response);
-        } else {
-          callback(error, result, response);
-        }
-      };
-
       if (streamLength > 0 && azureutil.objectIsNull(azureutil.tryGetValueChain(options, ['contentSettings', 'contentMD5'], null)) && options.storeBlobContentMD5) {
         azureutil.calculateMD5(stream, Math.min(self.singleBlobPutThresholdInBytes, streamLength), options, function (internalBuff, contentMD5) {
           azureutil.setObjectInnerPropertyValue(options, ['contentSettings', 'contentMD5'], contentMD5);
-          self._putBlockBlob(container, blob, internalBuff, null, internalBuff.length, options, finalCallback);
+          self._putBlockBlob(container, blob, internalBuff, null, internalBuff.length, options, callback);
         });
         stream.resume();
       } else {
         // Stream will resume when it has a pipe destination or a 'data' listener
-        self._putBlockBlob(container, blob, null, stream, streamLength, options, finalCallback);
+        self._putBlockBlob(container, blob, null, stream, streamLength, options, callback);
       }
     };
 
@@ -4231,7 +4223,7 @@ BlobService.prototype._uploadBlobFromStream = function (isNewBlob, container, bl
 * @param {string}             [options.leaseId]                             The lease identifier.
 * @param {string}             [options.transactionalContentMD5]             The MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
 * @param {object}             [options.metadata]                            The metadata key/value pairs.
-* @param {int}                [options.parallelOperationThreadCount]        Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]        The number of parallel operations that may be performed when uploading.
 * @param {bool}               [options.storeBlobContentMD5]                 Specifies whether the blob's ContentMD5 header should be set on uploads. The default value is true for block blobs.
 * @param {bool}               [options.useTransactionalMD5]                 Calculate and send/validate content MD5 for transactions.
 * @param {object}             [options.contentSettings]                     The content settings of the blob.
@@ -4680,7 +4672,7 @@ BlobService.prototype._updatePageBlobPagesImpl = function (container, blob, rang
 * @param {int}                streamLength                                  The length of the stream to upload.
 * @param {object|function}    [options]                                     The request options.
 * @param {SpeedSummary}       [options.speedSummary]                        The download tracker objects;
-* @param {int}                [options.parallelOperationThreadCount]        Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]        The number of parallel operations that may be performed when uploading.
 * @param {bool}               [options.absorbConditionalErrorsOnRetry]      Specifies whether to absorb the conditional error on retry. (For append blob only)
 * @param {int}                [options.maxBlobSize]                         The max length in bytes allowed for the append blob to grow to.
 * @param {int}                [options.appendPosition]                      The number indicating the byte offset to check for. The append will succeed only if the end position of the blob is equal to this number.
@@ -5186,7 +5178,7 @@ BlobService.prototype._setRangeContentMD5Header = function (webResource, options
 * @param {Stream}             writeStream                                 The write stream.
 * @param {object}             [options]                                   The request options.
 * @param {SpeedSummary}       [options.speedSummary]                      The download tracker objects.
-* @param {int}                [options.parallelOperationThreadCount]      Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]      The number of parallel operations that may be performed when uploading.
 * @param {string}             [options.snapshotId]                        The snapshot identifier.
 * @param {string}             [options.leaseId]                           The lease identifier.
 * @param {string}             [options.rangeStart]                        Return only the bytes of the blob in the specified range.

--- a/lib/services/blob/blobservice.node.js
+++ b/lib/services/blob/blobservice.node.js
@@ -41,7 +41,7 @@ var BlobConstants = Constants.BlobConstants;
 *                                                                         Set the option to true for small blobs.
 *                                                                         Parallel download and speed summary won't work with this option on.
 * @param {SpeedSummary}       [options.speedSummary]                      The download tracker objects.
-* @param {int}                [options.parallelOperationThreadCount]      Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]      The number of parallel operations that may be performed when uploading.
 * @param {string}             [options.snapshotId]                        The snapshot identifier.
 * @param {string}             [options.leaseId]                           The lease identifier.
 * @param {string}             [options.rangeStart]                        Return only the bytes of the blob in the specified range.
@@ -98,7 +98,7 @@ BlobService.prototype.getBlobToLocalFile = function (container, blob, localFileN
 * @param (string)             localFileName                                       The local path to the file to be uploaded.
 * @param {object}             [options]                                           The request options.
 * @param {SpeedSummary}       [options.speedSummary]                              The upload tracker objects.
-* @param {int}                [options.parallelOperationThreadCount]              Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]              The number of parallel operations that may be performed when uploading.
 * @param {string}             [options.leaseId]                                   The lease identifier.
 * @param {string}             [options.transactionalContentMD5]                   An MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
 * @param {object}             [options.metadata]                                  The metadata key/value pairs.
@@ -148,7 +148,7 @@ BlobService.prototype.createPageBlobFromLocalFile = function (container, blob, l
 * @param {string}             [options.leaseId]                             The lease identifier.
 * @param {string}             [options.transactionalContentMD5]             The MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
 * @param {object}             [options.metadata]                            The metadata key/value pairs.
-* @param {int}                [options.parallelOperationThreadCount]        Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]        The number of parallel operations that may be performed when uploading.
 * @param {bool}               [options.storeBlobContentMD5]                 Specifies whether the blob's ContentMD5 header should be set on uploads. The default value is true for block blobs.
 * @param {object}             [options.contentSettings]                     The content settings of the blob.
 * @param {string}             [options.contentSettings.contentType]         The MIME content type of the blob. The default type is application/octet-stream.
@@ -274,7 +274,8 @@ BlobService.prototype.appendFromLocalFile = function (container, blob, localFile
     v.callback(callback);
   });
   
-  var options = extend(true, {}, userOptions);  
+  var options = extend(true, {}, userOptions);
+  options.speedSummary = options.speedSummary || new SpeedSummary(blob);
 
   var self = this;
   fs.stat(localFileName, function (error, stat) {
@@ -292,7 +293,7 @@ BlobService.prototype.appendFromLocalFile = function (container, blob, localFile
     }
   });
   
-  return  options.speedSummary;
+  return options.speedSummary;
 };
 
 // Private methods
@@ -315,7 +316,7 @@ BlobService.prototype.appendFromLocalFile = function (container, blob, localFile
 * @param {string}             [options.leaseId]                             The lease identifier.
 * @param {string}             [options.transactionalContentMD5]             An MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
 * @param {object}             [options.metadata]                            The metadata key/value pairs.
-* @param {int}                [options.parallelOperationThreadCount]        Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]        The number of parallel operations that may be performed when uploading.
 * @param {bool}               [options.storeBlobContentMD5]                 Specifies whether the blob's ContentMD5 header should be set on uploads. The default value is true for block blobs.
 * @param {object}             [options.contentSettings]                     The content settings of the blob.
 * @param {string}             [options.contentSettings.contentType]         The MIME content type of the blob. The default type is application/octet-stream.
@@ -404,7 +405,7 @@ BlobService.prototype._createBlobFromLocalFile = function (container, blob, blob
 *                                                                         Set the option to true for small blobs.
 *                                                                         Parallel download and speed summary won't work with this option on.
 * @param {SpeedSummary}       [options.speedSummary]                      The download tracker objects.
-* @param {int}                [options.parallelOperationThreadCount]      Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]      The number of parallel operations that may be performed when uploading.
 * @param {string}             [options.snapshotId]                        The snapshot identifier.
 * @param {string}             [options.leaseId]                           The lease identifier.
 * @param {string}             [options.rangeStart]                        Return only the bytes of the blob in the specified range.

--- a/lib/services/file/fileservice.browser.js
+++ b/lib/services/file/fileservice.browser.js
@@ -16,5 +16,80 @@
 
 // Module dependencies.
 var FileService = require('./fileservice.core');
+var azureCommon = require('./../../common/common.browser');
+var extend = require('extend');
+
+var azureutil = azureCommon.util;
+var BrowserFileReadStream = azureCommon.BrowserFileReadStream;
+var SpeedSummary = azureCommon.SpeedSummary;
+var validate = azureCommon.validate;
+var ChunkStreamWithStream = azureCommon.ChunkStreamWithStream;
+
+/**
+* Uploads a file to storage from an HTML File object. If the file already exists on the service, it will be overwritten.
+* (Only available in the JavaScript Client Library for Browsers)
+*
+* @this {FileService}
+* @param {string}             share                                         The share name.
+* @param {string}             directory                                     The directory name. Use '' to refer to the base directory.
+* @param {string}             file                                          The file name. File names may not start or end with the delimiter '/'.
+* @param {File}               browserFile                                   The File object to be uploaded created by HTML File API.
+* @param {object}             [options]                                     The request options.
+* @param {SpeedSummary}       [options.speedSummary]                        The download tracker objects;
+* @param {bool}               [options.storeFileContentMD5]                 Specifies whether the file's ContentMD5 header should be set on uploads. 
+*                                                                           The default value is false for files.
+* @param {bool}               [options.useTransactionalMD5]                 Calculate and send/validate content MD5 for transactions.
+* @param {object}             [options.contentSettings]                     The file's content settings.
+* @param {string}             [options.contentSettings.contentType]         The MIME content type of the file. The default type is application/octet-stream.
+* @param {string}             [options.contentSettings.contentEncoding]     The content encodings that have been applied to the file.
+* @param {string}             [options.contentSettings.contentLanguage]     The natural languages used by this resource.
+* @param {string}             [options.contentSettings.cacheControl]        The file service stores this value but does not use or modify it.
+* @param {string}             [options.contentSettings.contentDisposition]  The file's content disposition.
+* @param {string}             [options.contentSettings.contentMD5]          The file's MD5 hash.
+* @param {object}             [options.metadata]                            The metadata key/value pairs.
+* @param {LocationMode}       [options.locationMode]                        Specifies the location mode used to decide which location the request should be sent to. 
+*                                                                           Please see StorageUtilities.LocationMode for the possible values.
+* @param {int}                [options.timeoutIntervalInMs]                 The server timeout interval, in milliseconds, to use for the request.
+* @param {int}                [options.clientRequestTimeoutInMs]            The timeout of client requests, in milliseconds, to use for the request.
+* @param {int}                [options.maximumExecutionTimeInMs]            The maximum execution time, in milliseconds, across all potential retries, to use when making this request.
+*                                                                           The maximum execution time interval begins at the time that the client begins building the request. The maximum
+*                                                                           execution time is checked intermittently while performing requests, and before executing retries.
+* @param {string}             [options.clientRequestId]                     A string that represents the client request ID with a 1KB character limit.
+* @param {bool}               [options.useNagleAlgorithm]                   Determines whether the Nagle algorithm is used; true to use the Nagle algorithm; otherwise, false.
+*                                                                           The default value is false.
+* @param {errorOrResult}      callback                                      `error` will contain information if an error occurs; 
+*                                                                           otherwise `[result]{@link FileResult}` will contain the file information.
+*                                                                           `response` will contain information related to this operation.
+* @return {SpeedSummary}
+*/
+FileService.prototype.createFileFromBrowserFile = function (share, directory, file, browserFile, optionsOrCallback, callback) {
+  var userOptions;
+  azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { userOptions = o; callback = c; });
+
+  validate.validateArgs('createFileFromBrowserFile', function (v) {
+    v.string(share, 'share');
+    v.stringAllowEmpty(directory, 'directory');
+    v.string(file, 'file');
+    v.browserFileIsValid(browserFile);
+    v.shareNameIsValid(share);
+    v.callback(callback);
+  });
+
+  var options = extend(true, {}, userOptions);
+  options.speedSummary = options.speedSummary || new SpeedSummary(file);
+
+  var self = this;
+  this.createFile(share, directory, file, browserFile.size, options, function (error) {
+    if (error) {
+      callback(error);
+    } else {
+      var stream = new BrowserFileReadStream(browserFile);
+      var chunkStream = new ChunkStreamWithStream(stream, { calcContentMd5: options.storeFileContentMD5 });
+      self._createFileFromChunkStream(share, directory, file, chunkStream, browserFile.size, options, callback);
+    }
+  });
+
+  return options.speedSummary;
+};
 
 module.exports = FileService;

--- a/lib/services/file/fileservice.core.js
+++ b/lib/services/file/fileservice.core.js
@@ -2340,7 +2340,7 @@ FileService.prototype.createReadStream = function (share, directory, file, optio
 *                                                                         Set the option to true for small files.
 *                                                                         Parallel download and speed summary won't work with this option on.
 * @param {SpeedSummary}       [options.speedSummary]                      The download tracker objects.
-* @param {int}                [options.parallelOperationThreadCount]      Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]      The number of parallel operations that may be performed when uploading.
 * @param {string}             [options.rangeStart]                        Return only the bytes of the file in the specified range.
 * @param {string}             [options.rangeEnd]                          Return only the bytes of the file in the specified range. 
 * @param {boolean}            [options.useTransactionalMD5]               When set to true, Calculate and send/validate content MD5 for transactions.
@@ -3106,7 +3106,7 @@ var request = this._updateFilesImpl(share, directory, file, rangeStart, rangeEnd
 * @param {int}                streamLength                                  The length of the stream to upload.
 * @param {object|function}    [options]                                     The request options.
 * @param {SpeedSummary}       [options.speedSummary]                        The download tracker objects;
-* @param {int}                [options.parallelOperationThreadCount]        Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]        The number of parallel operations that may be performed when uploading.
 * @param {bool}               [options.useTransactionalMD5]                 Calculate and send/validate content MD5 for transactions.
 * @param {bool}               [options.storeFileContentMD5]                 Specifies whether the file's ContentMD5 header should be set on uploads.
 * @param {string}             [options.contentSettings.contentType]         The MIME content type of the file. The default type is application/octet-stream.
@@ -3324,7 +3324,7 @@ FileService.prototype._getFileToStream = function (share, directory, file, write
 * @param {string}             file                                        The file name. File names may not start or end with the delimiter '/'.
 * @param {Stream}             writeStream                                 The write stream.
 * @param {object}             [options]                                   The request options.
-* @param {int}                [options.parallelOperationThreadCount]      Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]      The number of parallel operations that may be performed when uploading.
 * @param {string}             [options.rangeStart]                        Return only the bytes of the file in the specified range.
 * @param {string}             [options.rangeEnd]                          Return only the bytes of the file in the specified range. 
 * @param {boolean}            [options.useTransactionalMD5]               When set to true, Calculate and send/validate content MD5 for transactions.

--- a/lib/services/file/fileservice.node.js
+++ b/lib/services/file/fileservice.node.js
@@ -39,7 +39,7 @@ var validate = azureCommon.validate;
 *                                                                         Set the option to true for small files.
 *                                                                         Parallel download and speed summary won't work with this option on.
 * @param {SpeedSummary}       [options.speedSummary]                      The download tracker objects.
-* @param {int}                [options.parallelOperationThreadCount]      Parallel operation thread count.
+* @param {int}                [options.parallelOperationThreadCount]      The number of parallel operations that may be performed when uploading.
 * @param {string}             [options.rangeStart]                        Return only the bytes of the file in the specified range.
 * @param {string}             [options.rangeEnd]                          Return only the bytes of the file in the specified range.
 * @param {boolean}            [options.useTransactionalMD5]               When set to true, Calculate and send/validate content MD5 for transactions.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "devDependencies": {
     "browserify": "^13.3.0",
-    "browserify-fs": "^1.0.0",
     "batchflow": "0.4.0",
     "coveralls": "^2.11.4",
     "factor-bundle": "^2.5.0",
@@ -53,9 +52,6 @@
     "nock": "0.16",
     "nsp": "^2.2.0",
     "should": "1.2.x"
-  },
-  "browser": {
-    "fs": "browserify-fs"
   },
   "homepage": "http://github.com/Azure/azure-storage-node",
   "repository": {

--- a/typings/azure-storage/azure-storage.d.ts
+++ b/typings/azure-storage/azure-storage.d.ts
@@ -1058,7 +1058,7 @@ declare module azurestorage {
           * @param {string}             localFileName                               The local path to the file to be downloaded.
           * @param {object}             [options]                                   The request options.
           * @param {SpeedSummary}       [options.speedSummary]                      The upload tracker objects.
-          * @param {int}                [options.parallelOperationThreadCount]      Parallel operation thread count
+          * @param {int}                [options.parallelOperationThreadCount]      The number of parallel operations that may be performed when uploading.
           * @param {string}             [options.snapshotId]                        The snapshot identifier.
           * @param {string}             [options.leaseId]                           The lease identifier.
           * @param {string}             [options.rangeStart]                        Return only the bytes of the blob in the specified range.
@@ -1507,7 +1507,7 @@ declare module azurestorage {
           * @param (string)             localFileName                                   The local path to the file to be uploaded.
           * @param {object}             [options]                                       The request options.
           * @param {SpeedSummary}       [options.speedSummary]                          The upload tracker objects.
-          * @param {int}                [options.parallelOperationThreadCount]          Parallel operation thread count
+          * @param {int}                [options.parallelOperationThreadCount]          The number of parallel operations that may be performed when uploading.
           * @param {string}             [options.leaseId]                               The lease identifier.
           * @param {string}             [options.transactionalContentMD5]               An MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
           * @param {object}             [options.metadata]                              The metadata key/value pairs.
@@ -1537,6 +1537,51 @@ declare module azurestorage {
           createPageBlobFromLocalFile(container: string, blob: string, localFileName: string, callback: ErrorOrResult<BlobService.BlobResult>): common.streams.speedsummary.SpeedSummary;
 
           /**
+          * Uploads a page blob from an HTML file. If the blob already exists on the service, it will be overwritten.
+          * To avoid overwriting and instead throw an error if the blob exists, please pass in an accessConditions parameter in the options object.
+          * (Only available in the JavaScript Client Library for Browsers)
+          *
+          * @this {BlobService}
+          * @param {string}             container                                           The container name.
+          * @param {string}             blob                                                The blob name.
+          * @param {object}             browserFile                                         The File object to be uploaded created by HTML File API.
+          * @param {object}             [options]                                           The request options.
+          * @param {SpeedSummary}       [options.speedSummary]                              The upload tracker objects.
+          * @param {int}                [options.parallelOperationThreadCount]              The number of parallel operations that may be performed when uploading.
+          * @param {string}             [options.leaseId]                                   The lease identifier.
+          * @param {string}             [options.transactionalContentMD5]                   An MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
+          * @param {object}             [options.metadata]                                  The metadata key/value pairs.
+          * @param {bool}               [options.storeBlobContentMD5]                       Specifies whether the blob's ContentMD5 header should be set on uploads. 
+          *                                                                                 The default value is false for page blobs.
+          * @param {bool}               [options.useTransactionalMD5]                       Calculate and send/validate content MD5 for transactions.
+          * @param {object}             [options.contentSettings]                           The content settings of the blob.
+          * @param {string}             [options.contentSettings.contentType]               The MIME content type of the blob. The default type is application/octet-stream.
+          * @param {string}             [options.contentSettings.contentEncoding]           The content encodings that have been applied to the blob.
+          * @param {string}             [options.contentSettings.contentLanguage]           The natural languages used by this resource.
+          * @param {string}             [options.contentSettings.cacheControl]              The Blob service stores this value but does not use or modify it.
+          * @param {string}             [options.contentSettings.contentDisposition]        The blob's content disposition.
+          * @param {string}             [options.contentSettings.contentMD5]                The blob's MD5 hash.
+          * @param {AccessConditions}   [options.accessConditions]                          The access conditions.
+          * @param {LocationMode}       [options.locationMode]                              Specifies the location mode used to decide which location the request should be sent to. 
+          *                                                                                 Please see StorageUtilities.LocationMode for the possible values.
+          * @param {int}                [options.timeoutIntervalInMs]                       The server timeout interval, in milliseconds, to use for the request.
+          * @param {int}                [options.clientRequestTimeoutInMs]                  The timeout of client requests, in milliseconds, to use for the request.
+          * @param {int}                [options.maximumExecutionTimeInMs]                  The maximum execution time, in milliseconds, across all potential retries, to use when making this request.
+          *                                                                                 The maximum execution time interval begins at the time that the client begins building the request. The maximum
+          *                                                                                 execution time is checked intermittently while performing requests, and before executing retries.
+          * @param {string}             [options.clientRequestId]                           A string that represents the client request ID with a 1KB character limit.
+          * @param {bool}               [options.useNagleAlgorithm]                         Determines whether the Nagle algorithm is used; true to use the Nagle algorithm; otherwise, false.
+          *                                                                                 The default value is false.
+          * @param {errorOrResult}      callback                                            `error` will contain information
+          *                                                                                 if an error occurs; otherwise `[result]{@link BlobResult}` will contain
+          *                                                                                 the blob information.
+          *                                                                                 `response` will contain information related to this operation.
+          * @return {SpeedSummary}
+          */
+          createPageBlobFromBrowserFile(container: string, blob: string, browserFile: object, options: BlobService.CreatePageBlobOptions, callback: ErrorOrResult<BlobService.BlobResult>): common.streams.speedsummary.SpeedSummary;
+          createPageBlobFromBrowserFile(container: string, blob: string, browserFile: object, callback: ErrorOrResult<BlobService.BlobResult>): common.streams.speedsummary.SpeedSummary;
+
+          /**
           * Uploads a page blob from a stream.
           *
           * @this {BlobService}
@@ -1546,7 +1591,7 @@ declare module azurestorage {
           * @param {int}                streamLength                                    The length of the stream to upload.
           * @param {object}             [options]                                       The request options.
           * @param {SpeedSummary}       [options.speedSummary]                          The download tracker objects;
-          * @param {int}                [options.parallelOperationThreadCount]          Parallel operation thread count
+          * @param {int}                [options.parallelOperationThreadCount]          The number of parallel operations that may be performed when uploading.
           * @param {string}             [options.leaseId]                               The lease identifier.
           * @param {string}             [options.transactionalContentMD5]               An MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
           * @param {object}             [options.metadata]                              The metadata key/value pairs.
@@ -1586,7 +1631,7 @@ declare module azurestorage {
           * @param {string}             [options.leaseId]                               The lease identifier.
           * @param {string}             [options.transactionalContentMD5]               The MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
           * @param {object}             [options.metadata]                              The metadata key/value pairs.
-          * @param {int}                [options.parallelOperationThreadCount]          Parallel operation thread count
+          * @param {int}                [options.parallelOperationThreadCount]          The number of parallel operations that may be performed when uploading.
           * @param {bool}               [options.storeBlobContentMD5]                   Specifies whether the blob's ContentMD5 header should be set on uploads.
           *                                                                             The default value is false for page blobs and true for block blobs.
           * @param {bool}               [options.useTransactionalMD5]                   Calculate and send/validate content MD5 for transactions.
@@ -1633,7 +1678,7 @@ declare module azurestorage {
           * @param {string}             [options.leaseId]                               The lease identifier.
           * @param {string}             [options.transactionalContentMD5]               The MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
           * @param {object}             [options.metadata]                              The metadata key/value pairs.
-          * @param {int}                [options.parallelOperationThreadCount]          Parallel operation thread count
+          * @param {int}                [options.parallelOperationThreadCount]          The number of parallel operations that may be performed when uploading.
           * @param {bool}               [options.storeBlobContentMD5]                   Specifies whether the blob's ContentMD5 header should be set on uploads.
           *                                                                             The default value is false for page blobs and true for block blobs.
           * @param {bool}               [options.useTransactionalMD5]                   Calculate and send/validate content MD5 for transactions.
@@ -1832,7 +1877,7 @@ declare module azurestorage {
           * @param {string}             [options.leaseId]                               The lease identifier.
           * @param {string}             [options.transactionalContentMD5]               The MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
           * @param {object}             [options.metadata]                              The metadata key/value pairs.
-          * @param {int}                [options.parallelOperationThreadCount]          Parallel operation thread count
+          * @param {int}                [options.parallelOperationThreadCount]          The number of parallel operations that may be performed when uploading.
           * @param {bool}               [options.storeBlobContentMD5]                   Specifies whether the blob's ContentMD5 header should be set on uploads. The default value is true for block blobs.
           * @param {string}             [options.contentSettings.contentType]           The MIME content type of the blob. The default type is application/octet-stream.
           * @param {string}             [options.contentSettings.contentEncoding]       The content encodings that have been applied to the blob.
@@ -1858,6 +1903,50 @@ declare module azurestorage {
           */
           createBlockBlobFromLocalFile(container: string, blob: string, localFileName: string, options: BlobService.CreateBlockBlobRequestOptions, callback: ErrorOrResult<BlobService.BlobResult>): common.streams.speedsummary.SpeedSummary;
           createBlockBlobFromLocalFile(container: string, blob: string, localFileName: string, callback: ErrorOrResult<BlobService.BlobResult>): common.streams.speedsummary.SpeedSummary;
+
+          /**
+          * Creates a new block blob. If the blob already exists on the service, it will be overwritten.
+          * To avoid overwriting and instead throw an error if the blob exists, please pass in an accessConditions parameter in the options object.
+          * (Only available in the JavaScript Client Library for Browsers)
+          *
+          * @this {BlobService}
+          * @param {string}             container                                     The container name.
+          * @param {string}             blob                                          The blob name.
+          * @param {object}             browserFile                                   The File object to be uploaded created by HTML File API.
+          * @param {object}             [options]                                     The request options.
+          * @param {int}                [options.blockSize]                           The size of each block. Maximum is 100MB.
+          * @param {string}             [options.blockIdPrefix]                       The prefix to be used to generate the block id.
+          * @param {string}             [options.leaseId]                             The lease identifier.
+          * @param {string}             [options.transactionalContentMD5]             The MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
+          * @param {object}             [options.metadata]                            The metadata key/value pairs.
+          * @param {int}                [options.parallelOperationThreadCount]        The number of parallel operations that may be performed when uploading.
+          * @param {bool}               [options.storeBlobContentMD5]                 Specifies whether the blob's ContentMD5 header should be set on uploads. The default value is true for block blobs.
+          * @param {object}             [options.contentSettings]                     The content settings of the blob.
+          * @param {string}             [options.contentSettings.contentType]         The MIME content type of the blob. The default type is application/octet-stream.
+          * @param {string}             [options.contentSettings.contentEncoding]     The content encodings that have been applied to the blob.
+          * @param {string}             [options.contentSettings.contentLanguage]     The natural languages used by this resource.
+          * @param {string}             [options.contentSettings.cacheControl]        The Blob service stores this value but does not use or modify it.
+          * @param {string}             [options.contentSettings.contentDisposition]  The blob's content disposition.
+          * @param {string}             [options.contentSettings.contentMD5]          The blob's MD5 hash.
+          * @param {AccessConditions}   [options.accessConditions]                    The access conditions.
+          * @param {LocationMode}       [options.locationMode]                        Specifies the location mode used to decide which location the request should be sent to. 
+          *                                                                           Please see StorageUtilities.LocationMode for the possible values.
+          * @param {int}                [options.timeoutIntervalInMs]                 The server timeout interval, in milliseconds, to use for the request.
+          * @param {int}                [options.clientRequestTimeoutInMs]            The timeout of client requests, in milliseconds, to use for the request.
+          * @param {int}                [options.maximumExecutionTimeInMs]            The maximum execution time, in milliseconds, across all potential retries, to use when making this request.
+          *                                                                           The maximum execution time interval begins at the time that the client begins building the request. The maximum
+          *                                                                           execution time is checked intermittently while performing requests, and before executing retries.
+          * @param {string}             [options.clientRequestId]                     A string that represents the client request ID with a 1KB character limit.
+          * @param {bool}               [options.useNagleAlgorithm]                   Determines whether the Nagle algorithm is used; true to use the Nagle algorithm; otherwise, false.
+          *                                                                           The default value is false.
+          * @param {errorOrResult}      callback                                      `error` will contain information
+          *                                                                           if an error occurs; otherwise `[result]{@link BlobResult}` will contain
+          *                                                                           the blob information.
+          *                                                                           `response` will contain information related to this operation.
+          * @return {SpeedSummary}
+          */
+          createBlockBlobFromBrowserFile(container: string, blob: string, browserFile: object, options: BlobService.CreateBlockBlobRequestOptions, callback: ErrorOrResult<BlobService.BlobResult>): common.streams.speedsummary.SpeedSummary;
+          createBlockBlobFromBrowserFile(container: string, blob: string, browserFile: object, callback: ErrorOrResult<BlobService.BlobResult>): common.streams.speedsummary.SpeedSummary;
 
           /**
           * Uploads a block blob from a stream.
@@ -1887,7 +1976,7 @@ declare module azurestorage {
           * @param {string}             [options.leaseId]                               The lease identifier.
           * @param {string}             [options.transactionalContentMD5]               The MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
           * @param {object}             [options.metadata]                              The metadata key/value pairs.
-          * @param {int}                [options.parallelOperationThreadCount]          Parallel operation thread count
+          * @param {int}                [options.parallelOperationThreadCount]          The number of parallel operations that may be performed when uploading.
           * @param {bool}               [options.storeBlobContentMD5]                   Specifies whether the blob's ContentMD5 header should be set on uploads. The default value is true for block blobs.
           * @param {bool}               [options.useTransactionalMD5]                   Calculate and send/validate content MD5 for transactions.
           * @param {string}             [options.contentSettings.contentType]           The MIME content type of the blob. The default type is application/octet-stream.
@@ -1960,7 +2049,7 @@ declare module azurestorage {
           * @param {string}             [options.leaseId]                               The lease identifier.
           * @param {string}             [options.transactionalContentMD5]               The MD5 hash of the blob content. This hash is used to verify the integrity of the blob during transport.
           * @param {object}             [options.metadata]                              The metadata key/value pairs.
-          * @param {int}                [options.parallelOperationThreadCount]          Parallel operation thread count
+          * @param {int}                [options.parallelOperationThreadCount]          The number of parallel operations that may be performed when uploading.
           * @param {bool}               [options.storeBlobContentMD5]                   Specifies whether the blob's ContentMD5 header should be set on uploads.
           *                                                                             The default value is false for page blobs and true for block blobs.
           * @param {bool}               [options.useTransactionalMD5]                   Calculate and send/validate content MD5 for transactions.
@@ -2199,7 +2288,52 @@ declare module azurestorage {
           */
           createAppendBlobFromLocalFile(container: string, blob: string, localFileName: string, options: BlobService.CreateBlobRequestOptions, callback: ErrorOrResult<BlobService.BlobResult>): common.streams.speedsummary.SpeedSummary;
           createAppendBlobFromLocalFile(container: string, blob: string, localFileName: string, callback: ErrorOrResult<BlobService.BlobResult>): common.streams.speedsummary.SpeedSummary;
-          
+
+          /**
+          * Creates a new append blob from an HTML File object. If the blob already exists on the service, it will be overwritten.
+          * To avoid overwriting and instead throw an error if the blob exists, please pass in an accessConditions parameter in the options object.
+          * This API should be used strictly in a single writer scenario because the API internally uses the append-offset conditional header to avoid duplicate blocks.
+          * If you are guaranteed to have a single writer scenario, please look at options.absorbConditionalErrorsOnRetry and see if setting this flag to true is acceptable for you.
+          * If you want to append data to an already existing blob, please look at appendFromBrowserFile.
+          * (Only available in the JavaScript Client Library for Browsers)
+          *
+          * @this {BlobService}
+          * @param {string}             container                                     The container name.
+          * @param {string}             blob                                          The blob name.
+          * @param {object}             browserFile                                   The File object to be uploaded created by HTML File API.
+          * @param {object}             [options]                                     The request options.
+          * @param {bool}               [options.absorbConditionalErrorsOnRetry]      Specifies whether to absorb the conditional error on retry.
+          * @param {string}             [options.leaseId]                             The lease identifier. 
+          * @param {object}             [options.metadata]                            The metadata key/value pairs.
+          * @param {bool}               [options.storeBlobContentMD5]                 Specifies whether the blob's ContentMD5 header should be set on uploads. The default value is true for block blobs.
+          * @param {bool}               [options.useTransactionalMD5]                 Calculate and send/validate content MD5 for transactions.
+          * @param {object}             [options.contentSettings]                     The content settings of the blob.
+          * @param {string}             [options.contentSettings.contentType]         The MIME content type of the blob. The default type is application/octet-stream.
+          * @param {string}             [options.contentSettings.contentEncoding]     The content encodings that have been applied to the blob.
+          * @param {string}             [options.contentSettings.contentLanguage]     The natural languages used by this resource.
+          * @param {string}             [options.contentSettings.cacheControl]        The Blob service stores this value but does not use or modify it.
+          * @param {string}             [options.contentSettings.contentDisposition]  The blob's content disposition.
+          * @param {string}             [options.contentSettings.contentMD5]          The blob's MD5 ahash.
+          * @param {AccessConditions}   [options.accessConditions]                    The access conditions.
+          * @param {LocationMode}       [options.locationMode]                        Specifies the location mode used to decide which location the request should be sent to. 
+          *                                                                           Please see StorageUtilities.LocationMode for the possible values.
+          * @param {int}                [options.timeoutIntervalInMs]                 The server timeout interval, in milliseconds, to use for the request.
+          * @param {int}                [options.clientRequestTimeoutInMs]            The timeout of client requests, in milliseconds, to use for the request.
+          * @param {int}                [options.maximumExecutionTimeInMs]            The maximum execution time, in milliseconds, across all potential retries, to use when making this request.
+          *                                                                           The maximum execution time interval begins at the time that the client begins building the request. The maximum
+          *                                                                           execution time is checked intermittently while performing requests, and before executing retries.
+          * @param {string}             [options.clientRequestId]                     A string that represents the client request ID with a 1KB character limit.
+          * @param {bool}               [options.useNagleAlgorithm]                   Determines whether the Nagle algorithm is used; true to use the Nagle algorithm; otherwise, false.
+          *                                                                           The default value is false.
+          * @param {errorOrResult}      callback                                      `error` will contain information
+          *                                                                           if an error occurs; otherwise `[result]{@link BlobResult}` will contain
+          *                                                                           the blob information.
+          *                                                                           `response` will contain information related to this operation.
+          * @return {SpeedSummary}
+          */
+          createAppendBlobFromBrowserFile(container: string, blob: string, browserFile: object, options: BlobService.CreateBlobRequestOptions, callback: ErrorOrResult<BlobService.BlobResult>): common.streams.speedsummary.SpeedSummary;
+          createAppendBlobFromBrowserFile(container: string, blob: string, browserFile: object, callback: ErrorOrResult<BlobService.BlobResult>): common.streams.speedsummary.SpeedSummary;
+
           /**
           * Uploads an append blob from a stream. If the blob already exists on the service, it will be overwritten.
           * To avoid overwriting and instead throw an error if the blob exists, please pass in an accessConditions parameter in the options object.
@@ -2414,6 +2548,47 @@ declare module azurestorage {
           */
           appendFromLocalFile(container: string, blob: string, localFileName: string, options: BlobService.CreateBlobRequestOptions, callback: ErrorOrResult<BlobService.BlobResult>): common.streams.speedsummary.SpeedSummary;
           appendFromLocalFile(container: string, blob: string, localFileName: string, callback: ErrorOrResult<BlobService.BlobResult>): common.streams.speedsummary.SpeedSummary;
+
+          /**
+          * Appends to an append blob from an HTML File object. Assumes the blob already exists on the service.
+          * This API should be used strictly in a single writer scenario because the API internally uses the append-offset conditional header to avoid duplicate blocks.
+          * If you are guaranteed to have a single writer scenario, please look at options.absorbConditionalErrorsOnRetry and see if setting this flag to true is acceptable for you.
+          * (Only available in the JavaScript Client Library for Browsers)
+          *
+          * @this {BlobService}
+          * @param {string}             container                                     The container name.
+          * @param {string}             blob                                          The blob name.
+          * @param {object}             browserFile                                   The File object to be uploaded created by HTML File API.
+          * @param {object}             [options]                                     The request options.
+          * @param {bool}               [options.absorbConditionalErrorsOnRetry]      Specifies whether to absorb the conditional error on retry.
+          * @param {string}             [options.leaseId]                             The lease identifier.
+          * @param {object}             [options.metadata]                            The metadata key/value pairs.
+          * @param {object}             [options.contentSettings]                     The content settings of the blob.
+          * @param {string}             [options.contentSettings.contentType]         The MIME content type of the blob. The default type is application/octet-stream.
+          * @param {string}             [options.contentSettings.contentEncoding]     The content encodings that have been applied to the blob.
+          * @param {string}             [options.contentSettings.contentLanguage]     The natural languages used by this resource.
+          * @param {string}             [options.contentSettings.cacheControl]        The Blob service stores this value but does not use or modify it.
+          * @param {string}             [options.contentSettings.contentDisposition]  The blob's content disposition.
+          * @param {string}             [options.contentSettings.contentMD5]          The blob's MD5 hash.
+          * @param {AccessConditions}   [options.accessConditions]                    The access conditions.
+          * @param {LocationMode}       [options.locationMode]                        Specifies the location mode used to decide which location the request should be sent to. 
+          *                                                                           Please see StorageUtilities.LocationMode for the possible values.
+          * @param {int}                [options.timeoutIntervalInMs]                 The server timeout interval, in milliseconds, to use for the request.
+          * @param {int}                [options.clientRequestTimeoutInMs]            The timeout of client requests, in milliseconds, to use for the request.
+          * @param {int}                [options.maximumExecutionTimeInMs]            The maximum execution time, in milliseconds, across all potential retries, to use when making this request.
+          *                                                                           The maximum execution time interval begins at the time that the client begins building the request. The maximum
+          *                                                                           execution time is checked intermittently while performing requests, and before executing retries.
+          * @param {string}             [options.clientRequestId]                     A string that represents the client request ID with a 1KB character limit.
+          * @param {bool}               [options.useNagleAlgorithm]                   Determines whether the Nagle algorithm is used; true to use the Nagle algorithm; otherwise, false.
+          *                                                                           The default value is false.
+          * @param {errorOrResult}      callback                                      `error` will contain information
+          *                                                                           if an error occurs; otherwise `[result]{@link BlobResult}` will contain
+          *                                                                           the blob information.
+          *                                                                           `response` will contain information related to this operation.
+          * @return {SpeedSummary}
+          */
+          appendFromBrowserFile(container: string, blob: string, browserFile: object, options: BlobService.CreateBlobRequestOptions, callback: ErrorOrResult<BlobService.BlobResult>): common.streams.speedsummary.SpeedSummary;
+          appendFromBrowserFile(container: string, blob: string, browserFile: object, callback: ErrorOrResult<BlobService.BlobResult>): common.streams.speedsummary.SpeedSummary;
 
           /**
           * Appends to an append blob from a stream. Assumes the blob already exists on the service.
@@ -6870,6 +7045,46 @@ declare module azurestorage {
         */
         createFileFromLocalFile(share: string, directory: string, file: string, localFileName: string, options: FileService.CreateFileRequestOptions, callback: ErrorOrResult<FileService.FileResult>): common.streams.speedsummary.SpeedSummary;
         createFileFromLocalFile(share: string, directory: string, file: string, localFileName: string, callback: ErrorOrResult<FileService.FileResult>): common.streams.speedsummary.SpeedSummary;
+
+        /**
+        * Uploads a file to storage from an HTML File object. If the file already exists on the service, it will be overwritten.
+        * (Only available in the JavaScript Client Library for Browsers)
+        *
+        * @this {FileService}
+        * @param {string}             share                                         The share name.
+        * @param {string}             directory                                     The directory name. Use '' to refer to the base directory.
+        * @param {string}             file                                          The file name. File names may not start or end with the delimiter '/'.
+        * @param {object}             browserFile                                   The File object to be uploaded created by HTML File API.
+        * @param {object}             [options]                                     The request options.
+        * @param {SpeedSummary}       [options.speedSummary]                        The download tracker objects;
+        * @param {bool}               [options.storeFileContentMD5]                 Specifies whether the file's ContentMD5 header should be set on uploads. 
+        *                                                                           The default value is false for files.
+        * @param {bool}               [options.useTransactionalMD5]                 Calculate and send/validate content MD5 for transactions.
+        * @param {object}             [options.contentSettings]                     The file's content settings.
+        * @param {string}             [options.contentSettings.contentType]         The MIME content type of the file. The default type is application/octet-stream.
+        * @param {string}             [options.contentSettings.contentEncoding]     The content encodings that have been applied to the file.
+        * @param {string}             [options.contentSettings.contentLanguage]     The natural languages used by this resource.
+        * @param {string}             [options.contentSettings.cacheControl]        The file service stores this value but does not use or modify it.
+        * @param {string}             [options.contentSettings.contentDisposition]  The file's content disposition.
+        * @param {string}             [options.contentSettings.contentMD5]          The file's MD5 hash.
+        * @param {object}             [options.metadata]                            The metadata key/value pairs.
+        * @param {LocationMode}       [options.locationMode]                        Specifies the location mode used to decide which location the request should be sent to. 
+        *                                                                           Please see StorageUtilities.LocationMode for the possible values.
+        * @param {int}                [options.timeoutIntervalInMs]                 The server timeout interval, in milliseconds, to use for the request.
+        * @param {int}                [options.clientRequestTimeoutInMs]            The timeout of client requests, in milliseconds, to use for the request.
+        * @param {int}                [options.maximumExecutionTimeInMs]            The maximum execution time, in milliseconds, across all potential retries, to use when making this request.
+        *                                                                           The maximum execution time interval begins at the time that the client begins building the request. The maximum
+        *                                                                           execution time is checked intermittently while performing requests, and before executing retries.
+        * @param {string}             [options.clientRequestId]                     A string that represents the client request ID with a 1KB character limit.
+        * @param {bool}               [options.useNagleAlgorithm]                   Determines whether the Nagle algorithm is used; true to use the Nagle algorithm; otherwise, false.
+        *                                                                           The default value is false.
+        * @param {errorOrResult}      callback                                      `error` will contain information if an error occurs; 
+        *                                                                           otherwise `[result]{@link FileResult}` will contain the file information.
+        *                                                                           `response` will contain information related to this operation.
+        * @return {SpeedSummary}
+        */
+        createFileFromBrowserFile(share: string, directory: string, file: string, browserFile: object, options: FileService.CreateFileRequestOptions, callback: ErrorOrResult<FileService.FileResult>): common.streams.speedsummary.SpeedSummary;
+        createFileFromBrowserFile(share: string, directory: string, file: string, browserFile: object, callback: ErrorOrResult<FileService.FileResult>): common.streams.speedsummary.SpeedSummary; 
 
         /**
         * Uploads a file from a stream.


### PR DESCRIPTION
Added browser specific APIs for uploading files and blobs from browser File objects:
-  `BlobService.createBlockBlobFromBrowserFile`
-  `BlobService.createPageBlobFromBrowserFile`
-  `BlobService.createAppendBlobFromBrowserFile`
-  `BlobService.appendFromBrowserFile`
-  `FileService.createFileFromBrowserFile`

Updated sample-blob.html and sample-file.html for new uploading APIs.
Added TypeScript definitions for new uploading APIs.
Dropped dependency to browserify-fs.