### PR TITLE
add additional File Storage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,20 @@ To upload a file from a stream, the method **createFileFromStream** can be used.
  });
 ```
 
-There are other methods for uploading files also, such as **createFileFromText**.
+To create a file from a text string, the method **createFileFromText** can be used. A Node Buffer or ArrayBuffer object containing the text can also be supplied.
+
+```Javascript
+ var azure = require('azure-storage');
+ var fileService = azure.createFileService();
+
+ var text = 'Hello World!';
+
+ fileService.createFileFromText('taskshare', 'taskdirectory', 'taskfile', text, function(error, result, response) {
+   if (!error) {
+     // file created
+   }
+ });
+```
 
 There are also several ways to download files. For example, **getFileToStream** downloads the file to a stream:
   

--- a/README.md
+++ b/README.md
@@ -284,7 +284,25 @@ fileService.createFileFromLocalFile('taskshare', 'taskdirectory', 'taskfile', 't
 });
 ```
 
-There are other methods for uploading files also, such as **createFileFromText** or **createFileFromStream**.
+To upload a file from a stream, the method **createFileFromStream** can be used. The var `myFileBuffer` in the script below is a native Node Buffer, or ArrayBuffer object if within a browser environment.
+
+```Javascript
+ var stream = require('stream');
+ var azure = require('azure-storage');
+ var fileService = azure.createFileService();
+
+ var fileStream = new stream.Readable();
+ fileStream.push(myFileBuffer);
+ fileStream.push(null);
+
+ fileService.createFileFromStream('taskshare', 'taskdirectory', 'taskfile', fileStream, myFileBuffer.length, function(error, result, response) {
+   if (!error) {
+     // file uploaded
+   }
+ });
+```
+
+There are other methods for uploading files also, such as **createFileFromText**.
 
 There are also several ways to download files. For example, **getFileToStream** downloads the file to a stream:
   

--- a/lib/services/file/fileservice.core.js
+++ b/lib/services/file/fileservice.core.js
@@ -2657,6 +2657,17 @@ FileService.prototype.createRangesFromStream = function (share, directory, file,
 *                                                                           if an error occurs; otherwise `text` will contain the file contents,
 *                                                                           and `[file]{@link FileResult}` will contain the file information.
 *                                                                           `response` will contain information related to this operation.
+* @example
+* var azure = require('azure-storage');
+* var fileService = azure.createFileService();
+*
+* var text = 'Hello World!';
+*
+* fileService.createFileFromText('taskshare', 'taskdirectory', 'taskfile', text, function(error, result, response) {
+*   if (!error) {
+*     // file created
+*   }
+* });
 */
 FileService.prototype.createFileFromText = function (share, directory, file, text, optionsOrCallback, callback) {
   var userOptions;

--- a/lib/services/file/fileservice.core.js
+++ b/lib/services/file/fileservice.core.js
@@ -2729,6 +2729,20 @@ FileService.prototype.createFileFromText = function (share, directory, file, tex
 *                                                                           otherwise `[result]{@link FileResult}` will contain the file information.
 *                                                                           `response` will contain information related to this operation.
 * @return {SpeedSummary}
+* @example
+* var stream = require('stream');
+* var azure = require('azure-storage');
+* var fileService = azure.createFileService();
+*
+* var fileStream = new stream.Readable();
+* fileStream.push(myFileBuffer);
+* fileStream.push(null);
+*
+* fileService.createFileFromStream('taskshare', 'taskdirectory', 'taskfile', fileStream, myFileBuffer.length, function(error, result, response) {
+*   if (!error) {
+*     // file uploaded
+*   }
+* });
 */
 FileService.prototype.createFileFromStream = function(share, directory, file, stream, streamLength, optionsOrCallback, callback) {
   var userOptions;


### PR DESCRIPTION
Hi there! 👋 

Really dig using this Azure Storage SDK, thanks for the hard work in maintaining it 👍 

I wanted to use the `createFileFromStream` method recently from the File Storage Service of this SDK, and had to dig through the source code to figure out which parameters to supply. The very next day, I had a prominent Node community member coincidentally tweet at me asking about the same method and how to use it. I'm a Tech Evangelist for Microsoft so this kind of tweet is a common occurrence.

I went ahead and added an example in the docs for `createFileFromStream`. I didn't want `createFileFromText` to be lonely so I added an example for that too.

I hope the examples are to your liking; let me know if you'd like me to tweak any code or language. I wasn't sure whether or not to update the changelog - say the word and I'll do that too.

Thank you for considering this PR 🙇‍♀️ 
