### PR TITLE
Update the request and validator package dependencies

### DIFF
--- a/lib/common/streams/filereadstream.js
+++ b/lib/common/streams/filereadstream.js
@@ -244,7 +244,7 @@ FileReadStream.prototype.destroy = function () {
   }
 
   // when the stream is closed immediately after creating it
-  if (!validator.isInt(this._fd)) {
+  if (!validator.isInt('' + this._fd)) {
     this.once('open', close);
     return;
   }

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "json-edm-parser": "0.1.2",
     "md5.js": "1.3.4",
     "readable-stream": "~2.0.0",
-    "request": "~2.81.0",
+    "request": "~2.83.0",
     "underscore": "~1.8.3",
     "uuid": "^3.0.0",
-    "validator": "~3.35.0",
+    "validator": "~9.4.1",
     "xml2js": "0.2.8",
     "xmlbuilder": "0.4.3"
   },


### PR DESCRIPTION
See : https://snyk.io/vuln/npm:validator:20160218 and https://snyk.io/vuln/npm:validator:20180218
Suggested fix: update to validator >= 9.4.1

The type-coercion fix is a little blunt - i'm open to suggestions on how to do this better.