### PR TITLE
Allow non TLD hosts

### DIFF
--- a/lib/common/util/validate.js
+++ b/lib/common/util/validate.js
@@ -79,7 +79,7 @@ exports.isValidEnumValue = function (value, list, callback) {
 * @return {boolean}
 */
 exports.isValidUri = function (uri) {
-  if (!check.isURL(uri)){
+  if (!check.isURL(uri, { 'require_tld': false })){
     throw new URIError('The provided URI "' + uri + '" is invalid.');
   }
   return true;
@@ -97,12 +97,12 @@ exports.isValidHost= function (host) {
   } else {
     var storageHost = {};
     storageHost.primaryHost = _.isString(host) ? host : host.primaryHost;
-    if (storageHost.primaryHost && !check.isURL(storageHost.primaryHost)){
+    if (storageHost.primaryHost && !check.isURL(storageHost.primaryHost, { 'require_tld': false })){
       throw new URIError('The provided URI "' + storageHost.primaryHost + '" is invalid.');
     }
 
     storageHost.secondaryHost = _.isString(host) ? undefined : host.secondaryHost;
-    if (storageHost.secondaryHost && !check.isURL(storageHost.secondaryHost)){
+    if (storageHost.secondaryHost && !check.isURL(storageHost.secondaryHost, { 'require_tld': false })){
       throw new URIError('The provided URI "' + storageHost.secondaryHost + '" is invalid.');
     }
 

--- a/test/common/storageservicesettingstests.js
+++ b/test/common/storageservicesettingstests.js
@@ -94,6 +94,10 @@ describe('StorageServiceSettingsTests', function(done) {
       function () {blobServiceUsingExplicitHost.setHost({});}, 
       function (err) {return (typeof err.name === 'undefined' || err.name === 'ArgumentNullError') && err.message === 'The host for the storage service must be specified.';}
     );
+    assert.throws(
+      function () {blobServiceUsingExplicitHost.setHost('weird and invalid chars: 🦄💨');},
+      function (err) {return (err instanceof URIError) && err.message === 'The provided URI "weird and invalid chars: 🦄💨" is invalid.';}
+    )
 
     done();
   });

--- a/test/common/storageservicesettingstests.js
+++ b/test/common/storageservicesettingstests.js
@@ -94,10 +94,6 @@ describe('StorageServiceSettingsTests', function(done) {
       function () {blobServiceUsingExplicitHost.setHost({});}, 
       function (err) {return (typeof err.name === 'undefined' || err.name === 'ArgumentNullError') && err.message === 'The host for the storage service must be specified.';}
     );
-    assert.throws(
-      function () {blobServiceUsingExplicitHost.setHost('xyz');}, 
-      function (err) {return (err instanceof URIError) && err.message === 'The provided URI "xyz" is invalid.';}
-    );
 
     done();
   });

--- a/test/common/util/validate-tests.js
+++ b/test/common/util/validate-tests.js
@@ -37,12 +37,14 @@ describe('validator-tests', function () {
   it('isValidUri should work', function (done) {
     Validate.isValidUri('http://www.microsoft.com').should.be.ok;
     Validate.isValidUri('http://www.microsoft.com').should.equal(true);
+    Validate.isValidUri('http://non-tld-host').should.be.ok;
+    Validate.isValidUri('http://non-tld-host').should.equal(true);
     assert.throws(
       function() {
-        Validate.isValidUri('something');
+        Validate.isValidUri('http:///something');
       },
       function(err) {
-        return (err instanceof URIError) && err.message == 'The provided URI "something" is invalid.' 
+        return (err instanceof URIError) && err.message == 'The provided URI "http:///something" is invalid.'
       }
     );
     done();
@@ -50,12 +52,13 @@ describe('validator-tests', function () {
   
   it('isValidHost should work', function (done) {
     Validate.isValidHost('http://www.microsoft.com').should.be.ok;
+    Validate.isValidHost('http://non-tld-host').should.be.ok;
     assert.throws(
       function() {
-        Validate.isValidHost('something');
+        Validate.isValidHost('http:///something');
       },
       function(err) {
-        return (err instanceof URIError) && err.message == 'The provided URI "something" is invalid.' 
+        return (err instanceof URIError) && err.message == 'The provided URI "http:///something" is invalid.'
       }
     );
     done();


### PR DESCRIPTION
Not sure if I changed the tests appropriately here; I had to [remove a test in storageservicetests.js](https://github.com/Azure/azure-storage-node/commit/4727325fe97e729bd92599b4c7a65ae7a78c6827#diff-f06b7e1d10ed68e066b258381d1d2abdL100) because it was verifying an exception that will no longer be thrown, and I didn't know what to replace the test input with there that would still fail with the new requirements, but still allow TLDs.

This resolves #436.