### PR TITLE
Bumped version of request module from ~2.83.0 to ^2.86.0 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,11 @@
 Note: This is an Azure Storage only package. The all up Azure node sdk still has the old storage bits in there. In a future release, those storage bits will be removed and an npm dependency to this storage node sdk will 
 be taken. This is a GA release and the changes described below indicate the changes from the Azure node SDK 0.9.8 available here - https://github.com/Azure/azure-sdk-for-node.
 
+2018.05 Version 2.8.3
+
+ALL
+* Bumped version of request module from ~2.83.0 to ^2.86.0 to solve a vulnerability issue.
+
 2018.04 Version 2.8.2
 
 ALL

--- a/lib/common/util/constants.js
+++ b/lib/common/util/constants.js
@@ -37,7 +37,7 @@ var Constants = {
   * @const
   * @type {string}
   */
-  USER_AGENT_PRODUCT_VERSION: '2.8.2',
+  USER_AGENT_PRODUCT_VERSION: '2.8.3',
 
   /**
   * The number of default concurrent requests for parallel operation.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-storage",
   "author": "Microsoft Corporation",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "Microsoft Azure Storage Client Library for Node.js",
   "typings": "typings/azure-storage/azure-storage.d.ts",
   "tags": [
@@ -25,7 +25,7 @@
     "json-edm-parser": "0.1.2",
     "md5.js": "1.3.4",
     "readable-stream": "~2.0.0",
-    "request": "~2.83.0",
+    "request": "^2.86.0",
     "underscore": "~1.8.3",
     "uuid": "^3.0.0",
     "validator": "~9.4.1",


### PR DESCRIPTION
Bumped version of request module from ~2.83.0 to ^2.86.0 to solve a vulnerability issue #449 