### PR TITLE
Added method to list blobs and directories at the same time

### DIFF
--- a/lib/common/util/constants.js
+++ b/lib/common/util/constants.js
@@ -672,7 +672,7 @@ var Constants = {
     * @enum {string}
     */
     ListBlobTypes: {
-      Any: 'a',
+      All: 'a',
       Blob: 'b',
       Directory: 'd'
     },

--- a/lib/common/util/constants.js
+++ b/lib/common/util/constants.js
@@ -672,6 +672,7 @@ var Constants = {
     * @enum {string}
     */
     ListBlobTypes: {
+      Any: 'a',
       Blob: 'b',
       Directory: 'd'
     },

--- a/lib/services/blob/blobservice.core.js
+++ b/lib/services/blob/blobservice.core.js
@@ -1151,7 +1151,7 @@ BlobService.prototype.listBlobsOrBlobDirectoriesSegmentedWithPrefix = function (
   azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { userOptions = o; callback = c; });
   userOptions.delimiter = '/';
 
-  this._listBlobsOrDirectoriesSegmentedWithPrefix(container, prefix, currentToken, BlobConstants.ListBlobTypes.Any, userOptions, callback);
+  this._listBlobsOrDirectoriesSegmentedWithPrefix(container, prefix, currentToken, BlobConstants.ListBlobTypes.All, userOptions, callback);
 };
 
 /**
@@ -5816,37 +5816,45 @@ BlobService.prototype._listBlobsOrDirectoriesSegmentedWithPrefix = function (con
     if (!responseObject.error) {
       responseObject.listBlobsResult = {
         entries: null,
+        fileEntries: null,
+        directoryEntries: null,
         continuationToken: null
       };
 
-      responseObject.listBlobsResult.entries = [];
-      var results = [];
+      var fileEntries = null;
+      var directoryEntries = null;
 
-      if (listBlobType == BlobConstants.ListBlobTypes.Any && responseObject.response.body.EnumerationResults.Blobs) {
+      if (listBlobType == BlobConstants.ListBlobTypes.All && responseObject.response.body.EnumerationResults.Blobs) {
         var blobs = responseObject.response.body.EnumerationResults.Blobs;
         // concat converts non-arrays to arrays automatically
         if (blobs.BlobPrefix) {
-          results = results.concat(blobs.BlobPrefix);
+          fileEntries = [].concat(blobs.BlobPrefix);
         }
         if (blobs.Blob) {
-          results = results.concat(blobs.Blob);
+          directoryEntries = [].concat(blobs.Blob);
         }
       } else if (listBlobType == BlobConstants.ListBlobTypes.Directory && responseObject.response.body.EnumerationResults.Blobs.BlobPrefix) {
-        results = responseObject.response.body.EnumerationResults.Blobs.BlobPrefix;
-        if (!_.isArray(results)) {
-          results = [results];
-        }
+        directoryEntries = [].concat(responseObject.response.body.EnumerationResults.Blobs.BlobPrefix);
       } else if (listBlobType == BlobConstants.ListBlobTypes.Blob && responseObject.response.body.EnumerationResults.Blobs.Blob) {
-        results = responseObject.response.body.EnumerationResults.Blobs.Blob;
-        if (!_.isArray(results)) {
-          results = [results];
-        }
+        fileEntries = [].concat(responseObject.response.body.EnumerationResults.Blobs.Blob);
       }
 
-      results.forEach(function (currentBlob) {
-        var blobResult = BlobResult.parse(currentBlob);
-        responseObject.listBlobsResult.entries.push(blobResult);
-      });
+      var mapMethod = function (currentBlob) {
+        return BlobResult.parse(currentBlob);
+      };
+      if (fileEntries) {
+        responseObject.listBlobsResult.fileEntries = fileEntries.map(mapMethod);
+      }
+      if (directoryEntries) {
+        responseObject.listBlobsResult.directoryEntries = directoryEntries.map(mapMethod);
+      }
+
+      // if listBlobType isn't All, add the entries key in the return object for backwards compatibility
+      if (listBlobType == BlobConstants.ListBlobTypes.Directory) {
+        responseObject.listBlobsResult.entries = responseObject.listBlobsResult.directoryEntries;
+      } else if (listBlobType == BlobConstants.ListBlobTypes.Blob) {
+        responseObject.listBlobsResult.entries = responseObject.listBlobsResult.fileEntries;
+      }
 
       if (responseObject.response.body.EnumerationResults.NextMarker) {
         responseObject.listBlobsResult.continuationToken = {

--- a/lib/services/blob/blobservice.core.js
+++ b/lib/services/blob/blobservice.core.js
@@ -5826,8 +5826,7 @@ BlobService.prototype._listBlobsOrDircotriesSegmentedWithPrefix = function (cont
         var blobPrefixes = responseObject.response.body.EnumerationResults.Blobs.BlobPrefix;
         var blobs = responseObject.response.body.EnumerationResults.Blobs.Blob;
         results = [].concat(blobPrefixes, blobs); // concat converts non-arrays to arrays automatically
-      }
-      if (listBlobType == BlobConstants.ListBlobTypes.Directory && responseObject.response.body.EnumerationResults.Blobs.BlobPrefix) {
+      } else if (listBlobType == BlobConstants.ListBlobTypes.Directory && responseObject.response.body.EnumerationResults.Blobs.BlobPrefix) {
         results = responseObject.response.body.EnumerationResults.Blobs.BlobPrefix;
         if (!_.isArray(results)) {
           results = [results];

--- a/lib/services/blob/blobservice.core.js
+++ b/lib/services/blob/blobservice.core.js
@@ -5822,10 +5822,15 @@ BlobService.prototype._listBlobsOrDircotriesSegmentedWithPrefix = function (cont
       responseObject.listBlobsResult.entries = [];
       var results = [];
 
-      if (listBlobType == BlobConstants.ListBlobTypes.Any && (responseObject.response.body.EnumerationResults.Blobs.BlobPrefix || responseObject.response.body.EnumerationResults.Blobs.Blob)) {
-        var blobPrefixes = responseObject.response.body.EnumerationResults.Blobs.BlobPrefix;
-        var blobs = responseObject.response.body.EnumerationResults.Blobs.Blob;
-        results = [].concat(blobPrefixes, blobs); // concat converts non-arrays to arrays automatically
+      if (listBlobType == BlobConstants.ListBlobTypes.Any && responseObject.response.body.EnumerationResults.Blobs) {
+        var blobs = responseObject.response.body.EnumerationResults.Blobs;
+        // concat converts non-arrays to arrays automatically
+        if (blobs.BlobPrefix) {
+          results = results.concat(blobs.BlobPrefix);
+        }
+        if (blobs.Blob) {
+          results = results.concat(blobs.Blob);
+        }
       } else if (listBlobType == BlobConstants.ListBlobTypes.Directory && responseObject.response.body.EnumerationResults.Blobs.BlobPrefix) {
         results = responseObject.response.body.EnumerationResults.Blobs.BlobPrefix;
         if (!_.isArray(results)) {

--- a/lib/services/blob/blobservice.core.js
+++ b/lib/services/blob/blobservice.core.js
@@ -1082,8 +1082,8 @@ BlobService.prototype.deleteContainerIfExists = function (container, optionsOrCa
 * @param {bool}               [options.useNagleAlgorithm]         Determines whether the Nagle algorithm is used; true to use the Nagle algorithm; otherwise, false.
 *                                                                 The default value is false.
 * @param {errorOrResult}      callback                            `error` will contain information
-*                                                                 if an error occurs; otherwise `result` will contain `entries` and `continuationToken`. 
-*                                                                 `entries`  gives a list of `[directories]{@link DirectoryResult}` and the `continuationToken` is used for the next listing operation.
+*                                                                 if an error occurs; otherwise `result` will contain `directoryEntries` and `continuationToken`. 
+*                                                                 `directoryEntries` (with an alias in `entries` for backwards compatibility) gives a list of `[directories]{@link DirectoryResult}` and the `continuationToken` is used for the next listing operation.
 *                                                                 `response` will contain information related to this operation.
 */
 BlobService.prototype.listBlobDirectoriesSegmented = function (container, currentToken, optionsOrCallback, callback) {
@@ -1110,8 +1110,8 @@ BlobService.prototype.listBlobDirectoriesSegmented = function (container, curren
 * @param {bool}               [options.useNagleAlgorithm]         Determines whether the Nagle algorithm is used; true to use the Nagle algorithm; otherwise, false.
 *                                                                 The default value is false.
 * @param {errorOrResult}      callback                            `error` will contain information
-*                                                                 if an error occurs; otherwise `result` will contain `entries` and `continuationToken`. 
-*                                                                 `entries`  gives a list of `[directories]{@link BlobResult}` and the `continuationToken` is used for the next listing operation.
+*                                                                 if an error occurs; otherwise `result` will contain `directoryEntries` and `continuationToken`. 
+*                                                                 `directoryEntries` (with an alias in `entries` for backwards compatibility) gives a list of `[directories]{@link DirectoryResult}` and the `continuationToken` is used for the next listing operation.
 *                                                                 `response` will contain information related to this operation.
 */
 BlobService.prototype.listBlobDirectoriesSegmentedWithPrefix = function (container, prefix, currentToken, optionsOrCallback, callback) {
@@ -1142,7 +1142,7 @@ BlobService.prototype.listBlobDirectoriesSegmentedWithPrefix = function (contain
 *                                                                 The default value is false.
 * @param {errorOrResult}      callback                            `error` will contain information
 *                                                                 if an error occurs; otherwise `result` will contain `directoryEentries`, `fileEntries` and `continuationToken`. 
-*                                                                 `directoryEentries`  gives a list of `[directories]{@link BlobResult}`, `fileEntries` gives a list of `[blobs]{@link BlobResult}`, and the `continuationToken` is used for the next listing operation.
+*                                                                 `directoryEentries`  gives a list of `[directories]{@link DirectoryResult}`, `fileEntries` gives a list of `[blobs]{@link BlobResult}`, and the `continuationToken` is used for the next listing operation.
 *                                                                 `response` will contain information related to this operation.
 */
 BlobService.prototype.listBlobsOrBlobDirectoriesSegmented = function (container, currentToken, optionsOrCallback, callback) {
@@ -1170,7 +1170,7 @@ BlobService.prototype.listBlobsOrBlobDirectoriesSegmented = function (container,
 *                                                                 The default value is false.
 * @param {errorOrResult}      callback                            `error` will contain information
 *                                                                 if an error occurs; otherwise `result` will contain `directoryEentries`, `fileEntries` and `continuationToken`. 
-*                                                                 `directoryEentries`  gives a list of `[directories]{@link BlobResult}`, `fileEntries` gives a list of `[blobs]{@link BlobResult}`, and the `continuationToken` is used for the next listing operation.
+*                                                                 `directoryEentries`  gives a list of `[directories]{@link DirectoryResult}`, `fileEntries` gives a list of `[blobs]{@link BlobResult}`, and the `continuationToken` is used for the next listing operation.
 *                                                                 `response` will contain information related to this operation.
 */
 BlobService.prototype.listBlobsOrBlobDirectoriesSegmentedWithPrefix = function (container, prefix, currentToken, optionsOrCallback, callback) {
@@ -1204,8 +1204,8 @@ BlobService.prototype.listBlobsOrBlobDirectoriesSegmentedWithPrefix = function (
 * @param {bool}               [options.useNagleAlgorithm]         Determines whether the Nagle algorithm is used; true to use the Nagle algorithm; otherwise, false.
 *                                                                 The default value is false.
 * @param {errorOrResult}      callback                            `error` will contain information
-*                                                                 if an error occurs; otherwise `result` will contain `entries` and `continuationToken`. 
-*                                                                 `entries`  gives a list of `[blobs]{@link BlobResult}` and the `continuationToken` is used for the next listing operation.
+*                                                                 if an error occurs; otherwise `result` will contain `fileEntries` and `continuationToken`. 
+*                                                                 `fileEntries` (with an alias in `entries` for backwards compatibility) gives a list of `[blobs]{@link BlobResult}` and the `continuationToken` is used for the next listing operation.
 *                                                                 `response` will contain information related to this operation.
 */
 BlobService.prototype.listBlobsSegmented = function (container, currentToken, optionsOrCallback, callback) {
@@ -1236,10 +1236,9 @@ BlobService.prototype.listBlobsSegmented = function (container, currentToken, op
 * @param {bool}               [options.useNagleAlgorithm]         Determines whether the Nagle algorithm is used; true to use the Nagle algorithm; otherwise, false.
 *                                                                 The default value is false.
 * @param {errorOrResult}      callback                            `error` will contain information
-*                                                                 if an error occurs; otherwise `result` will contain
-*                                                                 the entries of `[blobs]{@link BlobResult}` and the continuation token for the next listing operation.
-*                                                                 `response` will contain information related to this operation.
-*/
+*                                                                 if an error occurs; otherwise `result` will contain `fileEntries` and `continuationToken`. 
+*                                                                 `fileEntries` (with an alias in `entries` for backwards compatibility) gives a list of `[blobs]{@link BlobResult}` and the `continuationToken` is used for the next listing operation.
+*                                                                 `response` will contain information related to this operation.*/
 BlobService.prototype.listBlobsSegmentedWithPrefix = function (container, prefix, currentToken, optionsOrCallback, callback) {
   this._listBlobsOrDirectoriesSegmentedWithPrefix(container, prefix, currentToken, BlobConstants.ListBlobTypes.Blob, optionsOrCallback, callback);
 };

--- a/lib/services/blob/blobservice.core.js
+++ b/lib/services/blob/blobservice.core.js
@@ -1127,6 +1127,33 @@ BlobService.prototype.listBlobDirectoriesSegmentedWithPrefix = function (contain
 *
 * @this {BlobService}
 * @param {string}             container                           The container name.
+* @param {object}             currentToken                        A continuation token returned by a previous listing operation. Please use 'null' or 'undefined' if this is the first operation.
+* @param {object}             [options]                           The request options.
+* @param {int}                [options.maxResults]                Specifies the maximum number of blobs or directories to return per call to Azure ServiceClient. This does NOT affect list size returned by this function. (maximum: 5000)
+* @param {LocationMode}       [options.locationMode]              Specifies the location mode used to decide which location the request should be sent to. 
+*                                                                 Please see StorageUtilities.LocationMode for the possible values.
+* @param {int}                [options.timeoutIntervalInMs]       The server timeout interval, in milliseconds, to use for the request.
+* @param {int}                [options.clientRequestTimeoutInMs]  The timeout of client requests, in milliseconds, to use for the request.
+* @param {int}                [options.maximumExecutionTimeInMs]  The maximum execution time, in milliseconds, across all potential retries, to use when making this request.
+*                                                                 The maximum execution time interval begins at the time that the client begins building the request. The maximum
+*                                                                 execution time is checked intermittently while performing requests, and before executing retries.
+* @param {string}             [options.clientRequestId]           A string that represents the client request ID with a 1KB character limit.
+* @param {bool}               [options.useNagleAlgorithm]         Determines whether the Nagle algorithm is used; true to use the Nagle algorithm; otherwise, false.
+*                                                                 The default value is false.
+* @param {errorOrResult}      callback                            `error` will contain information
+*                                                                 if an error occurs; otherwise `result` will contain `directoryEentries`, `fileEntries` and `continuationToken`. 
+*                                                                 `directoryEentries`  gives a list of `[directories]{@link BlobResult}`, `fileEntries` gives a list of `[blobs]{@link BlobResult}`, and the `continuationToken` is used for the next listing operation.
+*                                                                 `response` will contain information related to this operation.
+*/
+BlobService.prototype.listBlobsOrBlobDirectoriesSegmented = function (container, currentToken, optionsOrCallback, callback) {
+  this.listBlobsOrBlobDirectoriesSegmentedWithPrefix(container, null /* prefix */, currentToken, optionsOrCallback, callback);
+};
+
+/**
+* Lists a segment containing a collection of blob items or blob directories items in the container.
+*
+* @this {BlobService}
+* @param {string}             container                           The container name.
 * @param {string}             prefix                              The prefix of the blob directory or blob name.
 * @param {object}             currentToken                        A continuation token returned by a previous listing operation. Please use 'null' or 'undefined' if this is the first operation.
 * @param {object}             [options]                           The request options.
@@ -1142,8 +1169,8 @@ BlobService.prototype.listBlobDirectoriesSegmentedWithPrefix = function (contain
 * @param {bool}               [options.useNagleAlgorithm]         Determines whether the Nagle algorithm is used; true to use the Nagle algorithm; otherwise, false.
 *                                                                 The default value is false.
 * @param {errorOrResult}      callback                            `error` will contain information
-*                                                                 if an error occurs; otherwise `result` will contain `entries` and `continuationToken`. 
-*                                                                 `entries`  gives a list of `[directories]{@link BlobResult}` and the `continuationToken` is used for the next listing operation.
+*                                                                 if an error occurs; otherwise `result` will contain `directoryEentries`, `fileEntries` and `continuationToken`. 
+*                                                                 `directoryEentries`  gives a list of `[directories]{@link BlobResult}`, `fileEntries` gives a list of `[blobs]{@link BlobResult}`, and the `continuationToken` is used for the next listing operation.
 *                                                                 `response` will contain information related to this operation.
 */
 BlobService.prototype.listBlobsOrBlobDirectoriesSegmentedWithPrefix = function (container, prefix, currentToken, optionsOrCallback, callback) {

--- a/lib/services/blob/blobservice.core.js
+++ b/lib/services/blob/blobservice.core.js
@@ -1123,6 +1123,38 @@ BlobService.prototype.listBlobDirectoriesSegmentedWithPrefix = function (contain
 };
 
 /**
+* Lists a segment containing a collection of blob items or blob directories items in the container.
+*
+* @this {BlobService}
+* @param {string}             container                           The container name.
+* @param {string}             prefix                              The prefix of the blob directory or blob name.
+* @param {object}             currentToken                        A continuation token returned by a previous listing operation. Please use 'null' or 'undefined' if this is the first operation.
+* @param {object}             [options]                           The request options.
+* @param {int}                [options.maxResults]                Specifies the maximum number of blobs or directories to return per call to Azure ServiceClient. This does NOT affect list size returned by this function. (maximum: 5000)
+* @param {LocationMode}       [options.locationMode]              Specifies the location mode used to decide which location the request should be sent to. 
+*                                                                 Please see StorageUtilities.LocationMode for the possible values.
+* @param {int}                [options.timeoutIntervalInMs]       The server timeout interval, in milliseconds, to use for the request.
+* @param {int}                [options.clientRequestTimeoutInMs]  The timeout of client requests, in milliseconds, to use for the request.
+* @param {int}                [options.maximumExecutionTimeInMs]  The maximum execution time, in milliseconds, across all potential retries, to use when making this request.
+*                                                                 The maximum execution time interval begins at the time that the client begins building the request. The maximum
+*                                                                 execution time is checked intermittently while performing requests, and before executing retries.
+* @param {string}             [options.clientRequestId]           A string that represents the client request ID with a 1KB character limit.
+* @param {bool}               [options.useNagleAlgorithm]         Determines whether the Nagle algorithm is used; true to use the Nagle algorithm; otherwise, false.
+*                                                                 The default value is false.
+* @param {errorOrResult}      callback                            `error` will contain information
+*                                                                 if an error occurs; otherwise `result` will contain `entries` and `continuationToken`. 
+*                                                                 `entries`  gives a list of `[directories]{@link BlobResult}` and the `continuationToken` is used for the next listing operation.
+*                                                                 `response` will contain information related to this operation.
+*/
+BlobService.prototype.listBlobsOrBlobDirectoriesSegmentedWithPrefix = function (container, prefix, currentToken, optionsOrCallback, callback) {
+  var userOptions;
+  azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { userOptions = o; callback = c; });
+  userOptions.delimiter = '/';
+
+  this._listBlobsOrDircotriesSegmentedWithPrefix(container, prefix, currentToken, BlobConstants.ListBlobTypes.Any, userOptions, callback);
+};
+
+/**
 * Lists a segment containing a collection of blob items in the container.
 *
 * @this {BlobService}
@@ -5790,6 +5822,11 @@ BlobService.prototype._listBlobsOrDircotriesSegmentedWithPrefix = function (cont
       responseObject.listBlobsResult.entries = [];
       var results = [];
 
+      if (listBlobType == BlobConstants.ListBlobTypes.Any && (responseObject.response.body.EnumerationResults.Blobs.BlobPrefix || responseObject.response.body.EnumerationResults.Blobs.Blob)) {
+        var blobPrefixes = responseObject.response.body.EnumerationResults.Blobs.BlobPrefix;
+        var blobs = responseObject.response.body.EnumerationResults.Blobs.Blob;
+        results = [].concat(blobPrefixes, blobs); // concat converts non-arrays to arrays automatically
+      }
       if (listBlobType == BlobConstants.ListBlobTypes.Directory && responseObject.response.body.EnumerationResults.Blobs.BlobPrefix) {
         results = responseObject.response.body.EnumerationResults.Blobs.BlobPrefix;
         if (!_.isArray(results)) {

--- a/lib/services/blob/blobservice.core.js
+++ b/lib/services/blob/blobservice.core.js
@@ -1119,7 +1119,7 @@ BlobService.prototype.listBlobDirectoriesSegmentedWithPrefix = function (contain
   azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { userOptions = o; callback = c; });
   userOptions.delimiter = '/';
 
-  this._listBlobsOrDircotriesSegmentedWithPrefix(container, prefix, currentToken, BlobConstants.ListBlobTypes.Directory, userOptions, callback);
+  this._listBlobsOrDirectoriesSegmentedWithPrefix(container, prefix, currentToken, BlobConstants.ListBlobTypes.Directory, userOptions, callback);
 };
 
 /**
@@ -1151,7 +1151,7 @@ BlobService.prototype.listBlobsOrBlobDirectoriesSegmentedWithPrefix = function (
   azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { userOptions = o; callback = c; });
   userOptions.delimiter = '/';
 
-  this._listBlobsOrDircotriesSegmentedWithPrefix(container, prefix, currentToken, BlobConstants.ListBlobTypes.Any, userOptions, callback);
+  this._listBlobsOrDirectoriesSegmentedWithPrefix(container, prefix, currentToken, BlobConstants.ListBlobTypes.Any, userOptions, callback);
 };
 
 /**
@@ -1214,7 +1214,7 @@ BlobService.prototype.listBlobsSegmented = function (container, currentToken, op
 *                                                                 `response` will contain information related to this operation.
 */
 BlobService.prototype.listBlobsSegmentedWithPrefix = function (container, prefix, currentToken, optionsOrCallback, callback) {
-  this._listBlobsOrDircotriesSegmentedWithPrefix(container, prefix, currentToken, BlobConstants.ListBlobTypes.Blob, optionsOrCallback, callback);
+  this._listBlobsOrDirectoriesSegmentedWithPrefix(container, prefix, currentToken, BlobConstants.ListBlobTypes.Blob, optionsOrCallback, callback);
 };
 
 // Lease methods
@@ -5784,7 +5784,7 @@ BlobService.prototype._getBlobToStream = function (container, blob, writeStream,
 *                                                                 the entries of blobs and the continuation token for the next listing operation.
 *                                                                 `response` will contain information related to this operation.
 */
-BlobService.prototype._listBlobsOrDircotriesSegmentedWithPrefix = function (container, prefix, currentToken, listBlobType, optionsOrCallback, callback) {
+BlobService.prototype._listBlobsOrDirectoriesSegmentedWithPrefix = function (container, prefix, currentToken, listBlobType, optionsOrCallback, callback) {
   var userOptions;
   azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { userOptions = o; callback = c; });
 


### PR DESCRIPTION
This fixes the issue in #412, without asking users to rely on internal, undocumented methods. It also ensures that the Azure Storage SDK offers similar features to storage SDKs from AWS and others.

I could use some guidance on how to write tests for this, however, as understanding the test suite was no easy feat :) 