### PR TITLE
Change queryTable doc to use result.entries

### DIFF
--- a/lib/services/table/tableservice.js
+++ b/lib/services/table/tableservice.js
@@ -748,7 +748,7 @@ TableService.prototype.deleteTableIfExists = function (table, optionsOrCallback,
 * @param {TableService~propertyResolver}  [options.propertyResolver]               The property resolver. Given the partition key, row key, property name, property value,
 *                                                                                  and the property Edm type if given by the service, returns the Edm type of the property.
 * @param {TableService~queryResponse} callback                                     `error` will contain information if an error occurs; 
-*                                                                                  otherwise `entities` will contain the entities returned by the query. 
+*                                                                                  otherwise `entries` will contain the entities returned by the query. 
 *                                                                                  If more matching entities exist, and could not be returned,
 *                                                                                  `queryResultContinuation` will contain a continuation token that can be used
 *                                                                                  to retrieve the next set of results.
@@ -794,7 +794,7 @@ TableService.prototype.deleteTableIfExists = function (table, optionsOrCallback,
 * // returns all entities in tasktable, and a continuation token for the next page of results if necessary
 * tableService.queryEntities('tasktable', null, null \/*currentToken*\/, function(error, result) {
 *   if(!error) { 
-*     var entities = result.entities;
+*     var entities = result.entries;
 *     // do stuff with the returned entities if there are any
 *   }
 * });
@@ -803,7 +803,7 @@ TableService.prototype.deleteTableIfExists = function (table, optionsOrCallback,
 * var tableQuery = new TableQuery().select('field1', 'field2');
 * tableService.queryEntities('tasktable', tableQuery, null \/*currentToken*\/, function(error, result) {
 *   if(!error) { 
-*     var entities = result.entities;
+*     var entities = result.entries;
 *     // do stuff with the returned entities if there are any
 *   }
 * });
@@ -1384,7 +1384,7 @@ TableService.prototype.getUrl = function (table, sasToken, primary) {
 * Returns entities matched by a query.
 * @callback TableService~queryResponse                                                                                
 * @param {object} error                     If an error occurs, the error information.
-* @param {object} entities                  The entities returned by the query.
+* @param {object} entries                  The entities returned by the query.
 * @param {object} queryResultContinuation   If more matching entities exist, and could not be returned,
 *                                           a continuation token that can be used to retrieve more results.
 * @param {object} response                  Information related to this operation.


### PR DESCRIPTION
This threw me for a loop for about 30 minutes. The documentation says result.entitites will contain the entities returned from the query, but the code (line 849) uses result.entries.

http://azure.github.io/azure-storage-node/TableService.html#queryEntities

It might make more sense for everything to be entities, but unless both entities and entries are in the object, that would be a breaking change.

(Also, https://cla.azure.com in the guidelines is timing out, where (unencrypted/port 80) http://cla.azure.com redirect to https://cla.opensource.microsoft.com/)