### PR TITLE
Address uncaught TypeError in table service

### DIFF
--- a/lib/services/table/tableservice.js
+++ b/lib/services/table/tableservice.js
@@ -536,7 +536,7 @@ TableService.prototype.createTable = function (table, optionsOrCallback, callbac
   var processResponseCallback = function (responseObject, next) {
     responseObject.tableResponse = {};
     responseObject.tableResponse.isSuccessful = responseObject.error ? false : true;
-    responseObject.tableResponse.statusCode = responseObject.response.statusCode;
+    responseObject.tableResponse.statusCode = responseObject.response === null || responseObject.response === undefined ? undefined : responseObject.response.statusCode;
     if (!responseObject.error) {
       responseObject.tableResponse.TableName = table;
     }


### PR DESCRIPTION
Hi, thanks for this SDK. This is a minor fix for the following issue:

Fixes: https://github.com/Azure/azure-storage-node/issues/517

Checks for null responseObject.response before attempting to access statusCode property.

Tests pass locally.