### PR TITLE
Improved block upload error handling

### DIFF
--- a/lib/services/blob/blobservice.browser.js
+++ b/lib/services/blob/blobservice.browser.js
@@ -291,9 +291,9 @@ BlobService.prototype._createBlobFromBrowserFile = function (container, blob, bl
   options.speedSummary = options.speedSummary || new SpeedSummary(blob);
   
   var self = this;
-  var creationCallback = function (createError, createBlob, createResponse) {
+  var creationCallback = function (createError, createBlob, createResponse, createExtra) {
     if (createError) {
-      callback(createError, createBlob, createResponse);
+      callback(createError, createBlob, createResponse, createExtra);
     } else {
       // Automatically detect the mime type
       if(azureutil.tryGetValueChain(options, ['contentSettings','contentType'], undefined) === undefined) {
@@ -301,11 +301,11 @@ BlobService.prototype._createBlobFromBrowserFile = function (container, blob, bl
       }
 
       var stream = new BrowserFileReadStream(browserFile);
-      var streamCallback = function (createError, createBlob, createResponse) {
+      var streamCallback = function (createError, createBlob, createResponse, createExtra) {
         if (azureutil.objectIsFunction(stream.destroy)) {
           stream.destroy();
         }
-        callback(createError, createBlob, createResponse);
+        callback(createError, createBlob, createResponse, createExtra);
       };
       self._uploadBlobFromStream(true, container, blob, blobType, stream, browserFile.size, options, streamCallback);
     }

--- a/lib/services/blob/blobservice.core.js
+++ b/lib/services/blob/blobservice.core.js
@@ -4672,7 +4672,9 @@ BlobService.prototype._putBlockBlob = function (container, blob, text, stream, l
       if (!returnObject || !returnObject.error) {
         speedSummary.increment(length);
       }
-      callback(returnObject.error, returnObject.blobResult, returnObject.response);
+      callback(returnObject.error, returnObject.blobResult, returnObject.response,
+				{ container: container, blob: blob, ret_obj: returnObject }
+	  );
     };
 
     next(responseObject, finalCallback);
@@ -5230,12 +5232,19 @@ BlobService.prototype._uploadContentFromChunkStream = function (container, blob,
         if (error) {
           chunkStream.finish();
 
-          callback(error);
+          callback(error, null, null,
+                    { container: container, blob: blob }
+		  );
         } else {
           blobResult['commmittedBlocks'] = blockIds;
+		  // Make sure relevant information is relayed to callback
+          blobResult['container'] = container;
+          blobResult['name'] = blob;
 
           chunkStream.finish();
-          callback(error, blobResult, response);
+          callback(error, blobResult, response,
+                    { container: container, blob: blob }
+		  );
         }
       });
     } else {


### PR DESCRIPTION
It is imperative to get information which container/blob failed to upload. This is especially vital when multiple uploads are progressing. It is simply impossible to know which of them failed to transfer.

This patch adds transmitting the container and blob filename on blob upload errors.

Since my work is on client-side, I added an example with `<input type="file" />` upload via SAS having retry filter on upload.