### PR TITLE
Fix typo in blobservice.core private method name

### DIFF
--- a/lib/services/blob/blobservice.core.js
+++ b/lib/services/blob/blobservice.core.js
@@ -1121,7 +1121,7 @@ BlobService.prototype.listBlobDirectoriesSegmentedWithPrefix = function (contain
   azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { userOptions = o; callback = c; });
   userOptions.delimiter = '/';
 
-  this._listBlobsOrDircotriesSegmentedWithPrefix(container, prefix, currentToken, BlobConstants.ListBlobTypes.Directory, userOptions, callback);
+  this._listBlobsOrDirectoriesSegmentedWithPrefix(container, prefix, currentToken, BlobConstants.ListBlobTypes.Directory, userOptions, callback);
 };
 
 /**
@@ -1184,7 +1184,7 @@ BlobService.prototype.listBlobsSegmented = function (container, currentToken, op
 *                                                                 `response` will contain information related to this operation.
 */
 BlobService.prototype.listBlobsSegmentedWithPrefix = function (container, prefix, currentToken, optionsOrCallback, callback) {
-  this._listBlobsOrDircotriesSegmentedWithPrefix(container, prefix, currentToken, BlobConstants.ListBlobTypes.Blob, optionsOrCallback, callback);
+  this._listBlobsOrDirectoriesSegmentedWithPrefix(container, prefix, currentToken, BlobConstants.ListBlobTypes.Blob, optionsOrCallback, callback);
 };
 
 // Lease methods
@@ -5754,7 +5754,7 @@ BlobService.prototype._getBlobToStream = function (container, blob, writeStream,
 *                                                                 the entries of blobs and the continuation token for the next listing operation.
 *                                                                 `response` will contain information related to this operation.
 */
-BlobService.prototype._listBlobsOrDircotriesSegmentedWithPrefix = function (container, prefix, currentToken, listBlobType, optionsOrCallback, callback) {
+BlobService.prototype._listBlobsOrDirectoriesSegmentedWithPrefix = function (container, prefix, currentToken, listBlobType, optionsOrCallback, callback) {
   var userOptions;
   azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { userOptions = o; callback = c; });
 


### PR DESCRIPTION
Just a small typo fix, I discovered while browsing the code.