### PR TITLE
Fix for #614.

### DIFF
--- a/lib/common/util/validate.js
+++ b/lib/common/util/validate.js
@@ -338,8 +338,7 @@ exports.tableNameIsValid = function (table, callback) {
     return fail(new RangeError('Table name cannot be \'Tables\'.'));
   }
 
-  if (table.match(/^([A-Za-z][A-Za-z0-9]{2,62})$/) !== null || table === '$MetricsCapacityBlob' || table.match(/^(\$Metrics(HourPrimary|MinutePrimary|HourSecondary|MinuteSecondary)?(Transactions)(Blob|Queue|Table|File))$/) !== null)
-  {
+  if (/[^/?#\\]*[^/?# \\]/.test(table) || table === '$MetricsCapacityBlob' || /^(\$Metrics(HourPrimary|MinutePrimary|HourSecondary|MinuteSecondary)?(Transactions)(Blob|Queue|Table|File))$/.test(table)) {
     callback();
     return true;
   } else {


### PR DESCRIPTION
CosmosDB from portal uses `[^/?#\\]*[^/?# \\]` regex for validation of the table name.
It allow all special characters at any place. The table name can start with a special character!!! except for the characters negated into the above regex.

Now, using the same regex as the portal here.
The regex allowes all weird characters: https://regex101.com/r/fNEuRg/1

Insted of `String#match`, I used `RegExp#test` as it suits the use case here. `match` is used for string extraction, while `test` is used for pattern validation.