### PR TITLE
The regex match check(skip or allow) for cosmosdb.

### DIFF
--- a/lib/azure-storage.js
+++ b/lib/azure-storage.js
@@ -52,14 +52,15 @@ exports.TableUtilities = require('./services/table/tableutilities');
 * environment variables will be used.
 *
 * @param {string} [storageAccountOrConnectionString]  The storage account or the connection string.
+* @param {boolean} [skipRegExMatch]                   The regex match check(skip or allow) for cosmosdb.
 * @param {string} [storageAccessKey]                  The storage access key.
 * @param {string|object} [host]                       The host address. To define primary only, pass a string. 
 *                                                     Otherwise 'host.primaryHost' defines the primary host and 'host.secondaryHost' defines the secondary host.
 * @return {TableService}                              A new TableService object.
 *
 */
-exports.createTableService = function (storageAccountOrConnectionString, storageAccessKey, host) {
-  return new TableService(storageAccountOrConnectionString, storageAccessKey, host);
+exports.createTableService = function (storageAccountOrConnectionString, skipRegExMatch, storageAccessKey, host) {
+  return new TableService(storageAccountOrConnectionString, skipRegExMatch, storageAccessKey, host);
 };
 
 /**
@@ -71,7 +72,7 @@ exports.createTableService = function (storageAccountOrConnectionString, storage
 * @return {TableService}                              A new TableService object with the SAS credentials.
 */
 exports.createTableServiceWithSas = function (hostUri, sasToken) {
-  return new TableService(null, null, hostUri, sasToken);
+  return new TableService(null, false,null, hostUri, sasToken);
 };
 
 /**

--- a/lib/common/util/validate.js
+++ b/lib/common/util/validate.js
@@ -317,8 +317,9 @@ exports.queueNameIsValid = function (queueName, callback) {
 * Validates a table name.
 *
 * @param {string} table  The table name.
+* @param {boolean} skipRegExMatch skips regex match for cosmosdb
 */
-exports.tableNameIsValid = function (table, callback) {
+exports.tableNameIsValid = function (table, skipRegExMatch, callback) {
   var fail;
 
   initCallback(callback, function (f, cb) {
@@ -338,13 +339,17 @@ exports.tableNameIsValid = function (table, callback) {
     return fail(new RangeError('Table name cannot be \'Tables\'.'));
   }
 
-  if (table.match(/^([A-Za-z][A-Za-z0-9]{2,62})$/) !== null || table === '$MetricsCapacityBlob' || table.match(/^(\$Metrics(HourPrimary|MinutePrimary|HourSecondary|MinuteSecondary)?(Transactions)(Blob|Queue|Table|File))$/) !== null)
-  {
+  if (skipRegExMatch == true){
     callback();
     return true;
-  } else {
-    return fail(new SyntaxError('Table name format is incorrect.'));
-  }
+  } else if (table.match(/^([A-Za-z][A-Za-z0-9]{2,62})$/) !== null || table === '$MetricsCapacityBlob' || table.match(/^(\$Metrics(HourPrimary|MinutePrimary|HourSecondary|MinuteSecondary)?(Transactions)(Blob|Queue|Table|File))$/) !== null)
+   {
+     callback();
+     return true;
+   } else {
+     return fail(new SyntaxError('Table name format is incorrect.'));
+   }
+ 
 };
 
 /**

--- a/lib/services/table/tableservice.js
+++ b/lib/services/table/tableservice.js
@@ -67,13 +67,14 @@ var TableUtilities = require('./tableutilities');
 * @extends {StorageServiceClient}
 *
 * @param {string} [storageAccountOrConnectionString]  The storage account or the connection string.
+* @param {boolean} [skipRegExMatch]                   The storage access key.
 * @param {string} [storageAccessKey]                  The storage access key.
 * @param {string|object} [host]                       The host address. To define primary only, pass a string. 
 *                                                     Otherwise 'host.primaryHost' defines the primary host and 'host.secondaryHost' defines the secondary host.
 * @param {string} [sasToken]                          The Shared Access Signature token.
 * @param {string} [endpointSuffix]                    The endpoint suffix.
 */
-function TableService(storageAccountOrConnectionString, storageAccessKey, host, sasToken, endpointSuffix) {
+function TableService(storageAccountOrConnectionString, skipRegExMatch, storageAccessKey, host, sasToken, endpointSuffix) {
   var storageServiceSettings = StorageServiceClient.getStorageSettings(storageAccountOrConnectionString, storageAccessKey, host, sasToken, endpointSuffix);
 
   TableService['super_'].call(this,
@@ -92,6 +93,8 @@ function TableService(storageAccountOrConnectionString, storageAccessKey, host, 
   }
 
   this.defaultPayloadFormat = TableUtilities.PayloadFormat.MINIMAL_METADATA;
+
+  this.skipRegExMatch = skipRegExMatch;
 }
 
 util.inherits(TableService, StorageServiceClient);
@@ -338,10 +341,12 @@ TableService.prototype.listTablesSegmentedWithPrefix = function (prefix, current
 TableService.prototype.getTableAcl = function (table, optionsOrCallback, callback) {
   var userOptions;
   azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { userOptions = o; callback = c; });
+  
+  var tableService = this;
 
   validate.validateArgs('getTableAcl', function (v) {
     v.string(table, 'table');
-    v.tableNameIsValid(table);
+    v.tableNameIsValid(table, tableService.skipRegExMatch);
     v.callback(callback);
   });
 
@@ -393,9 +398,11 @@ TableService.prototype.setTableAcl = function (table, signedIdentifiers, options
   var userOptions;
   azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { userOptions = o; callback = c; });
 
+  var tableService = this;
+
   validate.validateArgs('setTableAcl', function (v) {
     v.string(table, 'table');
-    v.tableNameIsValid(table);
+    v.tableNameIsValid(table, tableService.skipRegExMatch);
     v.callback(callback);
   });
 
@@ -460,9 +467,11 @@ TableService.prototype.generateSharedAccessSignature = function (table, sharedAc
     throw new Error(SR.CANNOT_CREATE_SAS_WITHOUT_ACCOUNT_KEY);
   }
 
+  var tableService = this;
+
   validate.validateArgs('generateSharedAccessSignature', function (v) {
     v.string(table, 'table');
-    v.tableNameIsValid(table);
+    v.tableNameIsValid(table, tableService.skipRegExMatch);
     v.object(sharedAccessPolicy, 'sharedAccessPolicy');
   });
   
@@ -518,9 +527,11 @@ TableService.prototype.createTable = function (table, optionsOrCallback, callbac
   var userOptions;
   azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { userOptions = o; callback = c; });
 
+  var tableService = this;
+
   validate.validateArgs('createTable', function (v) {
     v.string(table, 'table');
-    v.tableNameIsValid(table);
+    v.tableNameIsValid(table, tableService.skipRegExMatch);
     v.callback(callback);
   });
 
@@ -584,9 +595,11 @@ TableService.prototype.createTableIfNotExists = function (table, optionsOrCallba
   var userOptions;
   azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { userOptions = o; callback = c; });
 
+  var tableService = this;
+
   validate.validateArgs('createTableIfNotExists', function (v) {
     v.string(table, 'table');
-    v.tableNameIsValid(table);
+    v.tableNameIsValid(table, tableService.skipRegExMatch);
     v.callback(callback);
   });
 
@@ -642,9 +655,11 @@ TableService.prototype.deleteTable = function (table, optionsOrCallback, callbac
   var userOptions;
   azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { userOptions = o; callback = c; });
 
+  var tableService = this;
+
   validate.validateArgs('deleteTable', function (v) {
     v.string(table, 'table');
-    v.tableNameIsValid(table);
+    v.tableNameIsValid(table, tableService.skipRegExMatch);
     v.callback(callback);
   });
 
@@ -688,9 +703,11 @@ TableService.prototype.deleteTableIfExists = function (table, optionsOrCallback,
   var userOptions;
   azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { userOptions = o; callback = c; });
 
+  var tableService = this;
+
   validate.validateArgs('deleteTableIfExists', function (v) {
     v.string(table, 'table');
-    v.tableNameIsValid(table);
+    v.tableNameIsValid(table, tableService.skipRegExMatch);
     v.callback(callback);
   });
 
@@ -1148,9 +1165,11 @@ TableService.prototype.executeBatch = function (table, batch, optionsOrCallback,
   var userOptions;
   azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { userOptions = o; callback = c; });
 
+  var tableService = this;
+
   validate.validateArgs('executeBatch', function (v) {
     v.string(table, 'table');
-    v.tableNameIsValid(table);
+    v.tableNameIsValid(table, tableService.skipRegExMatch);
     v.object(batch, 'batch');
     v.callback(callback);
   });
@@ -1226,9 +1245,11 @@ TableService.prototype._doesTableExist = function (table, primaryOnly, optionsOr
   var userOptions;
   azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { userOptions = o; callback = c; });
 
+  var tableService = this;
+
   validate.validateArgs('doesTableExist', function (v) {
     v.string(table, 'table');
-    v.tableNameIsValid(table);
+    v.tableNameIsValid(table, tableService.skipRegExMatch);
     v.callback(callback);
   });
 
@@ -1294,9 +1315,11 @@ TableService.prototype._performEntityOperation = function (operation, table, ent
   var userOptions;
   azureutil.normalizeArgs(optionsOrCallback, callback, function (o, c) { userOptions = o; callback = c; });
 
+  var tableService = this;
+
   validate.validateArgs('entityOperation', function (v) {
     v.string(table, 'table');
-    v.tableNameIsValid(table);
+    v.tableNameIsValid(table, tableService.skipRegExMatch);
     v.object(entityDescriptor, 'entityDescriptor');
 
     if(typeof entityDescriptor.PartitionKey !== 'string') {
@@ -1361,9 +1384,12 @@ TableService.prototype._performEntityOperation = function (operation, table, ent
 * var sasUrl = tableService.getUrl(table, sasToken);
 */
 TableService.prototype.getUrl = function (table, sasToken, primary) {
+
+  var tableService = this;
+
   validate.validateArgs('getUrl', function (v) {
     v.string(table, 'table');
-    v.tableNameIsValid(table);
+    v.tableNameIsValid(table, tableService.skipRegExMatch);
   });
 
   return this._getUrl(table, sasToken, primary);

--- a/typings/azure-storage/azure-storage.d.ts
+++ b/typings/azure-storage/azure-storage.d.ts
@@ -8871,8 +8871,9 @@ declare module azurestorage {
         * Validates a table name.
         *
         * @param {string} table  The table name.
+        * @param {boolean} skipRegExMatch The regex match check(skip or allow) for cosmosdb
         */
-        export function tableNameIsValid(table: string, callback?: Function): boolean;
+        export function tableNameIsValid(table: string, skipRegExMatch?: boolean, callback?: Function): boolean;
         /**
         * Validates page ranges.
         *
@@ -8889,7 +8890,7 @@ declare module azurestorage {
         export function blobTypeIsValid(type: string, callback?: Function): boolean;
         export class ArgumentValidator {
           func: string;
-          tableNameIsValid: (tableName: string, callback?: Function) => boolean;
+          tableNameIsValid: (tableName: string, skipRegExMatch?: boolean, callback?: Function) => boolean;
           containerNameIsValid: (containerName: string, callback?: Function) => boolean;
           shareNameIsValid: (shareName: string, callback?: Function) => boolean;
           blobNameIsValid: (containerName: string, blobName: string, callback?: Function) => boolean;
@@ -9495,6 +9496,7 @@ declare module azurestorage {
   * environment variables will be used.
   *
   * @param {string} [storageAccountOrConnectionString]  The storage account or the connection string.
+  * @param {boolean} [skipRegExMatch]                   The regex match check(skip or allow) for cosmosdb. 
   * @param {string} [storageAccessKey]                  The storage access key.
   * @param {string|object} [host]                       The host address. To define primary only, pass a string.
   *                                                     Otherwise 'host.primaryHost' defines the primary host and 'host.secondaryHost' defines the secondary host.
@@ -9502,7 +9504,7 @@ declare module azurestorage {
   *
   */
   export function createTableService(): TableService;
-  export function createTableService(connectionString: string): TableService;
+  export function createTableService(connectionString: string, skipRegExMatch?:boolean): TableService;
   export function createTableService(storageAccountOrConnectionString: string, storageAccessKey: string, host?: StorageHost): TableService;
 
   /**


### PR DESCRIPTION
This boolean flag has been passed in table service instance, which will skip the regex validation for all table operations. The remaining validations apart from regex check are unchanged. This is a specific requirement for CosmosDB table name validation.