### PR TITLE
Fix genjs

### DIFF
--- a/browser/bundle.js
+++ b/browser/bundle.js
@@ -53,7 +53,7 @@ function build(exportFilePath, outputFilePath, moduleName, isMinify) {
         if (isMinify) {
             result = UglifyJS.minify(code.trim());
             if (result.error) {
-                console.error('Minify failed when parsing', exportFilePath, err);
+                console.error('Minify failed when parsing', exportFilePath, result.error);
                 return;
             }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -950,12 +950,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-      "dev": true
-    },
     "component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
@@ -5923,22 +5917,10 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.3.28",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.28.tgz",
-      "integrity": "sha512-68Rc/aA6cswiaQ5SrE979UJcXX+ADA1z33/ZsPd+fbAiVdjZ16OXdbtGO+rJUUBgK6qdf3SOPhQf3K/ybF5Miw==",
-      "dev": true,
-      "requires": {
-        "commander": "~2.15.0",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
+      "version": "3.12.8",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.8.tgz",
+      "integrity": "sha512-fvBeuXOsvqjecUtF/l1dwsrrf5y2BCUk9AOJGzGcm6tE7vegku5u/YvqjyDaAGr422PLoLnrxg3EnRvTqsdC1w==",
+      "dev": true
     },
     "ultron": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "mocha-lcov-reporter": "^1.0.0",
     "nock": "0.16",
     "should": "1.2.x",
-    "uglify-js": "~3.3.9",
+    "uglify-js": "~3.12.8",
     "watchify": "^3.11.0"
   },
   "homepage": "http://github.com/Azure/azure-storage-node",


### PR DESCRIPTION
Uglify is failing because version 3.3.9 doesn't support ES6. 
The variable used to print the error there was incorrect.

I think I should the packages from https://github.com/Azure/azure-sdk-for-js/ right?
