### PR TITLE
Update underscore to 1.12.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5972,9 +5972,9 @@
       }
     },
     "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "underscore.string": {
       "version": "3.3.5",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "md5.js": "1.3.4",
     "readable-stream": "~2.0.0",
     "request": "^2.86.0",
-    "underscore": "~1.8.3",
+    "underscore": "^1.12.1",
     "uuid": "^3.0.0",
     "validator": "~9.4.1",
     "xml2js": "0.2.8",


### PR DESCRIPTION
Component Governance from DevOps complains of the underscore dependency in azure-sdk-for-js repo.
- Pulled in by event-processor-host since it depends on azure-storage
- Need to update underscore to ^1.12.1 to fix the problem
